### PR TITLE
feat: add ServerName parameter to public functions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -128,7 +128,7 @@ jobs:
           PLEX_TEST_SECTION_ID: ${{ secrets.PLEX_TEST_SECTION_ID }}
           PLEX_TEST_SECTION_NAME: ${{ secrets.PLEX_TEST_SECTION_NAME }}
           PLEX_TEST_LIBRARY_PATH: ${{ secrets.PLEX_TEST_LIBRARY_PATH }}
-          PLEX_ALLOW_MUTATIONS: 'false'
+          PLEX_ALLOW_LIBRARY_REFRESH: 'false'
         run: |
           if (-not $env:PLEX_SERVER_URI -or -not $env:PLEX_TOKEN) {
             Write-Host "::warning::Integration tests skipped - PLEX_SERVER_URI or PLEX_TOKEN secrets not configured"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -128,7 +128,7 @@ jobs:
           PLEX_TEST_SECTION_ID: ${{ secrets.PLEX_TEST_SECTION_ID }}
           PLEX_TEST_SECTION_NAME: ${{ secrets.PLEX_TEST_SECTION_NAME }}
           PLEX_TEST_LIBRARY_PATH: ${{ secrets.PLEX_TEST_LIBRARY_PATH }}
-          PLEX_ALLOW_LIBRARY_REFRESH: 'false'
+          PLEX_ALLOW_LIBRARY_REFRESH: ${{ secrets.PLEX_ALLOW_LIBRARY_REFRESH }}
         run: |
           if (-not $env:PLEX_SERVER_URI -or -not $env:PLEX_TOKEN) {
             Write-Host "::warning::Integration tests skipped - PLEX_SERVER_URI or PLEX_TOKEN secrets not configured"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-01-09
+
+### Added
+
+- New `-ServerName` parameter on 26+ public functions for easier server targeting
+  - Use stored server names instead of remembering URIs and tokens
+  - Works with `Get-PatServer`, `Get-PatLibrary`, `Sync-PatMedia`, `Update-PatLibrary`, and more
+  - Mutually exclusive with `-ServerUri` parameter
+- New `Test-PatServer` function to validate server connectivity and authentication
+- New private helper `Resolve-PatServerContext` for consistent server resolution across all functions
+
 ## [0.9.0] - 2026-01-06
 
 ### Added

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PlexAutomationToolkit.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.9.0'
+ModuleVersion = '0.10.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -104,6 +104,7 @@ FunctionsToExport = @(
     'Sync-PatMedia'
     'Sync-PatWatchStatus'
     'Test-PatLibraryPath'
+    'Test-PatServer'
     'Update-PatLibrary'
     'Wait-PatLibraryScan'
 )

--- a/PlexAutomationToolkit/Private/Get-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatServerToken.ps1
@@ -31,6 +31,7 @@ function Get-PatServerToken {
     [OutputType([string])]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'ByName')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $ServerName,
 

--- a/PlexAutomationToolkit/Private/Get-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatServerToken.ps1
@@ -31,7 +31,6 @@ function Get-PatServerToken {
     [OutputType([string])]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'ByName')]
-        [ValidateNotNullOrEmpty()]
         [string]
         $ServerName,
 

--- a/PlexAutomationToolkit/Private/Remove-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Private/Remove-PatServerToken.ps1
@@ -34,7 +34,7 @@ function Remove-PatServerToken {
         try {
             # Check if secret exists using Get-SecretInfo (doesn't expose the actual secret)
             $secretInfo = Get-SecretInfo -Name $secretName -ErrorAction SilentlyContinue
-            if ($secretInfo) {
+            if ($secretInfo -and $secretInfo.Vault) {
                 # Use the vault from secretInfo to avoid prompting when multiple vaults exist
                 Remove-Secret -Name $secretName -Vault $secretInfo.Vault -ErrorAction Stop
                 Write-Debug "Removed token from vault '$($secretInfo.Vault)' for server '$ServerName'"

--- a/PlexAutomationToolkit/Private/Resolve-PatServerContext.ps1
+++ b/PlexAutomationToolkit/Private/Resolve-PatServerContext.ps1
@@ -7,7 +7,7 @@ function Resolve-PatServerContext {
         Centralizes the logic for resolving which Plex server to use and obtaining
         the appropriate authentication headers. This helper eliminates duplicated
         boilerplate across cmdlets and provides a consistent pattern for handling
-        both explicit ServerUri parameters and default server configurations.
+        explicit ServerUri parameters, stored server names, and default server configurations.
 
         When using a stored server with local URI configuration, this function
         intelligently selects the best URI based on network reachability. If the
@@ -19,6 +19,11 @@ function Resolve-PatServerContext {
         internal cmdlet-to-cmdlet calls: when using the default server, child
         cmdlets should NOT receive ServerUri so they can perform their own default
         server resolution with proper authentication.
+
+    .PARAMETER ServerName
+        Optional name of a stored server to use. The server must be configured via
+        Add-PatServer. This is more convenient than ServerUri as you don't need to
+        remember the URI or provide a token.
 
     .PARAMETER ServerUri
         Optional URI of the Plex server. If not specified, uses the default stored server.
@@ -45,6 +50,10 @@ function Resolve-PatServerContext {
         - IsLocalConnection: Boolean indicating if using a local network connection
 
     .EXAMPLE
+        $ctx = Resolve-PatServerContext -ServerName 'Home'
+        $response = Invoke-PatApi -Uri $ctx.Uri -Headers $ctx.Headers
+
+    .EXAMPLE
         $ctx = Resolve-PatServerContext -ServerUri $ServerUri
         $response = Invoke-PatApi -Uri $ctx.Uri -Headers $ctx.Headers
 
@@ -68,6 +77,10 @@ function Resolve-PatServerContext {
     param(
         [Parameter(Mandatory = $false)]
         [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
+        [string]
         $ServerUri,
 
         [Parameter(Mandatory = $false)]
@@ -82,6 +95,41 @@ function Resolve-PatServerContext {
         [switch]
         $ForceRemote
     )
+
+    # Validate that ServerName and ServerUri are not both specified
+    if ($ServerName -and $ServerUri) {
+        throw "Cannot specify both -ServerName and -ServerUri. Use -ServerName for stored servers or -ServerUri for direct connection."
+    }
+
+    # ServerName - look up the stored server
+    if ($ServerName) {
+        Write-Verbose "Using stored server by name: $ServerName"
+        $server = Get-PatStoredServer -Name $ServerName -ErrorAction 'Stop'
+
+        # Get authentication token for the named server
+        $serverToken = Get-PatServerToken -ServerConfig $server
+
+        # Use intelligent URI selection if server has local URI configured
+        $selectedUri = $server.uri
+        $isLocal = $false
+
+        if ($server.localUri -or $ForceLocal -or $ForceRemote) {
+            $selection = Select-PatServerUri -Server $server -Token $serverToken -ForceLocal:$ForceLocal -ForceRemote:$ForceRemote
+            $selectedUri = $selection.Uri
+            $isLocal = $selection.IsLocal
+            Write-Verbose "URI selection: $($selection.SelectionReason)"
+        }
+
+        Write-Verbose "Using named server '$ServerName': $selectedUri (local: $isLocal)"
+        return [PSCustomObject]@{
+            Uri               = $selectedUri
+            Headers           = Get-PatAuthenticationHeader -Server $server
+            WasExplicitUri    = $false
+            Server            = $server
+            Token             = $null
+            IsLocalConnection = $isLocal
+        }
+    }
 
     if ($ServerUri) {
         Write-Verbose "Using explicitly specified server: $ServerUri"

--- a/PlexAutomationToolkit/Private/Resolve-PatServerContext.ps1
+++ b/PlexAutomationToolkit/Private/Resolve-PatServerContext.ps1
@@ -148,9 +148,15 @@ function Resolve-PatServerContext {
         }
     }
 
-    $server = Get-PatStoredServer -Default -ErrorAction 'Stop'
+    try {
+        $server = Get-PatStoredServer -Default -ErrorAction 'Stop'
+    }
+    catch {
+        throw "No server specified and failed to retrieve default server. Use -ServerName, -ServerUri, or configure a default server with Add-PatServer -Default. Error: $($_.Exception.Message)"
+    }
+
     if (-not $server) {
-        throw "No default server configured. Use Add-PatServer with -Default or specify -ServerUri."
+        throw "No default server configured. Use Add-PatServer with -Default, or specify -ServerName or -ServerUri."
     }
 
     # Get authentication token for reachability testing

--- a/PlexAutomationToolkit/Private/Set-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Private/Set-PatServerToken.ps1
@@ -37,6 +37,7 @@ function Set-PatServerToken {
     [OutputType([PSCustomObject])]
     param (
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]
         $ServerName,
 

--- a/PlexAutomationToolkit/Private/Set-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Private/Set-PatServerToken.ps1
@@ -37,7 +37,6 @@ function Set-PatServerToken {
     [OutputType([PSCustomObject])]
     param (
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [string]
         $ServerName,
 

--- a/PlexAutomationToolkit/Public/Add-PatCollectionItem.ps1
+++ b/PlexAutomationToolkit/Public/Add-PatCollectionItem.ps1
@@ -26,6 +26,10 @@ function Add-PatCollectionItem {
         One or more media item rating keys to add to the collection.
         Rating keys can be obtained from library browsing commands like Get-PatLibraryItem.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -41,6 +45,11 @@ function Add-PatCollectionItem {
         Add-PatCollectionItem -CollectionId 12345 -RatingKey 67890
 
         Adds the media item with rating key 67890 to collection 12345.
+
+    .EXAMPLE
+        Add-PatCollectionItem -CollectionName 'Marvel' -LibraryName 'Movies' -RatingKey 67890 -ServerName 'Home'
+
+        Adds an item to a collection on the stored server named 'Home'.
 
     .EXAMPLE
         Add-PatCollectionItem -CollectionName 'Marvel Movies' -LibraryName 'Movies' -RatingKey 111, 222, 333
@@ -93,6 +102,10 @@ function Add-PatCollectionItem {
         $RatingKey,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -110,7 +123,7 @@ function Add-PatCollectionItem {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Add-PatPlaylistItem.ps1
+++ b/PlexAutomationToolkit/Public/Add-PatPlaylistItem.ps1
@@ -18,6 +18,10 @@ function Add-PatPlaylistItem {
         One or more media item rating keys to add to the playlist.
         Rating keys can be obtained from library browsing commands like Get-PatLibraryItem.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -33,6 +37,11 @@ function Add-PatPlaylistItem {
         Add-PatPlaylistItem -PlaylistId 12345 -RatingKey 67890
 
         Adds the media item with rating key 67890 to playlist 12345.
+
+    .EXAMPLE
+        Add-PatPlaylistItem -PlaylistName 'My Playlist' -RatingKey 67890 -ServerName 'Home'
+
+        Adds an item to a playlist on the stored server named 'Home'.
 
     .EXAMPLE
         Add-PatPlaylistItem -PlaylistName 'My Favorites' -RatingKey 111, 222, 333
@@ -74,6 +83,10 @@ function Add-PatPlaylistItem {
         $RatingKey,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -91,7 +104,7 @@ function Add-PatPlaylistItem {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Get-PatCollection.ps1
+++ b/PlexAutomationToolkit/Public/Get-PatCollection.ps1
@@ -27,6 +27,10 @@ function Get-PatCollection {
         When specified, also retrieves the items within each collection.
         Items are returned in a nested 'Items' property on each collection object.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -39,6 +43,11 @@ function Get-PatCollection {
         Get-PatCollection
 
         Retrieves all collections from all libraries on the default server.
+
+    .EXAMPLE
+        Get-PatCollection -ServerName 'Home' -LibraryName 'Movies'
+
+        Retrieves all collections from the 'Movies' library on the 'Home' server.
 
     .EXAMPLE
         Get-PatCollection -LibraryName 'Movies'
@@ -111,6 +120,10 @@ function Get-PatCollection {
         $IncludeItems,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -124,7 +137,7 @@ function Get-PatCollection {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Get-PatPlaylist.ps1
+++ b/PlexAutomationToolkit/Public/Get-PatPlaylist.ps1
@@ -18,6 +18,10 @@ function Get-PatPlaylist {
         When specified, also retrieves the items within each playlist.
         Items are returned in a nested 'Items' property on each playlist object.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -30,6 +34,11 @@ function Get-PatPlaylist {
         Get-PatPlaylist
 
         Retrieves all playlists from the default Plex server.
+
+    .EXAMPLE
+        Get-PatPlaylist -ServerName 'Home'
+
+        Retrieves all playlists from the stored server named 'Home'.
 
     .EXAMPLE
         Get-PatPlaylist -PlaylistId 12345
@@ -82,6 +91,10 @@ function Get-PatPlaylist {
         $IncludeItems,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -95,7 +108,7 @@ function Get-PatPlaylist {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Get-PatServer.ps1
+++ b/PlexAutomationToolkit/Public/Get-PatServer.ps1
@@ -6,6 +6,10 @@ function Get-PatServer {
     .DESCRIPTION
         Gets information about a Plex server including version, platform, and capabilities.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400)
         If not specified, uses the default stored server.
@@ -13,6 +17,11 @@ function Get-PatServer {
     .PARAMETER Token
         The Plex authentication token. Required when using -ServerUri to authenticate
         with the server. If not specified with -ServerUri, requests may fail with 401.
+
+    .EXAMPLE
+        Get-PatServer -ServerName 'Home'
+
+        Retrieves server information from the stored server named 'Home'.
 
     .EXAMPLE
         Get-PatServer -ServerUri "http://plex.example.com:32400"
@@ -36,6 +45,10 @@ function Get-PatServer {
     #>
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
         [Parameter(Mandatory = $false, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
@@ -49,50 +62,35 @@ function Get-PatServer {
     )
 
     begin {
-        # Will store server for default case
-        $defaultServer = $null
+        # Cache for server context when using ServerName or default
+        $script:cachedContext = $null
+        if ($ServerName -or (-not $ServerUri -and -not $Token)) {
+            try {
+                $script:cachedContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
+            }
+            catch {
+                throw "Failed to resolve server: $($_.Exception.Message)"
+            }
+        }
     }
 
     process {
-        # Use default server if ServerUri not specified
-        $server = $null
-        $effectiveUri = $ServerUri
-        if (-not $ServerUri) {
-            # Cache default server lookup
-            if (-not $defaultServer) {
-                try {
-                    $defaultServer = Get-PatStoredServer -Default -ErrorAction 'Stop'
-                    if (-not $defaultServer) {
-                        throw "No default server configured. Use Add-PatServer with -Default or specify -ServerUri."
-                    }
-                    Write-Verbose "Using default server: $($defaultServer.uri)"
-                }
-                catch {
-                    throw "Failed to get default server: $($_.Exception.Message)"
-                }
+        # Use cached context or resolve for pipeline input
+        $serverContext = $script:cachedContext
+        if (-not $serverContext) {
+            try {
+                $serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
             }
-            $server = $defaultServer
-            $effectiveUri = $server.uri
+            catch {
+                throw "Failed to resolve server: $($_.Exception.Message)"
+            }
         }
-        else {
-            Write-Verbose "Using specified server: $ServerUri"
-        }
+
+        $effectiveUri = $serverContext.Uri
+        $headers = $serverContext.Headers
 
         Write-Verbose "Retrieving server information from $effectiveUri"
         $uri = Join-PatUri -BaseUri $effectiveUri -Endpoint '/'
-
-        # Build headers with authentication if we have server object or token
-        $headers = if ($server) {
-            Get-PatAuthenticationHeader -Server $server
-        }
-        else {
-            $h = @{ Accept = 'application/json' }
-            if (-not [string]::IsNullOrWhiteSpace($Token)) {
-                $h['X-Plex-Token'] = $Token
-                Write-Debug "Adding X-Plex-Token header for authenticated request"
-            }
-            $h
-        }
 
         try {
             $result = Invoke-PatApi -Uri $uri -Headers $headers -ErrorAction 'Stop'

--- a/PlexAutomationToolkit/Public/Get-PatServer.ps1
+++ b/PlexAutomationToolkit/Public/Get-PatServer.ps1
@@ -62,11 +62,12 @@ function Get-PatServer {
     )
 
     begin {
-        # Cache for server context when using ServerName or default
+        # Cache for server context when using ServerName (not pipeline-compatible)
+        # Default server resolution is deferred to process block to support pipeline input
         $script:cachedContext = $null
-        if ($ServerName -or (-not $ServerUri -and -not $Token)) {
+        if ($ServerName) {
             try {
-                $script:cachedContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
+                $script:cachedContext = Resolve-PatServerContext -ServerName $ServerName
             }
             catch {
                 throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Import-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Public/Import-PatServerToken.ps1
@@ -55,7 +55,6 @@ function Import-PatServerToken {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param (
         [Parameter(Mandatory = $false)]
-        [ValidateNotNullOrEmpty()]
         [string]
         $ServerName,
 

--- a/PlexAutomationToolkit/Public/New-PatCollection.ps1
+++ b/PlexAutomationToolkit/Public/New-PatCollection.ps1
@@ -24,6 +24,10 @@ function New-PatCollection {
         At least one item is required. Rating keys can be obtained from library
         browsing commands like Get-PatLibraryItem.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -39,6 +43,11 @@ function New-PatCollection {
         New-PatCollection -Title 'Marvel Movies' -LibraryName 'Movies' -RatingKey 12345
 
         Creates a new collection named 'Marvel Movies' in the Movies library with one item.
+
+    .EXAMPLE
+        New-PatCollection -Title 'DC Movies' -LibraryName 'Movies' -RatingKey 12345 -ServerName 'Home'
+
+        Creates a collection on the stored server named 'Home'.
 
     .EXAMPLE
         New-PatCollection -Title 'Horror Classics' -LibraryName 'Movies' -RatingKey 111, 222, 333 -PassThru
@@ -86,6 +95,10 @@ function New-PatCollection {
         $RatingKey,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -103,7 +116,7 @@ function New-PatCollection {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/New-PatPlaylist.ps1
+++ b/PlexAutomationToolkit/Public/New-PatPlaylist.ps1
@@ -22,6 +22,10 @@ function New-PatPlaylist {
         At least one rating key is required. Rating keys can be obtained from
         library browsing commands like Get-PatLibraryItem.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -82,6 +86,10 @@ function New-PatPlaylist {
         $RatingKey,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -99,7 +107,7 @@ function New-PatPlaylist {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Remove-PatCollection.ps1
+++ b/PlexAutomationToolkit/Public/Remove-PatCollection.ps1
@@ -23,6 +23,10 @@ function Remove-PatCollection {
         The library section ID containing the collection. Required when using -CollectionName.
         Use Get-PatLibrary to find library IDs.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -38,6 +42,11 @@ function Remove-PatCollection {
         Remove-PatCollection -CollectionId 12345
 
         Removes the collection with ID 12345 after confirmation.
+
+    .EXAMPLE
+        Remove-PatCollection -CollectionName 'Old' -LibraryName 'Movies' -ServerName 'Home' -Confirm:$false
+
+        Removes a collection from the stored server named 'Home'.
 
     .EXAMPLE
         Remove-PatCollection -CollectionName 'Old Collection' -LibraryName 'Movies' -Confirm:$false
@@ -88,6 +97,10 @@ function Remove-PatCollection {
         $LibraryId,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -105,7 +118,7 @@ function Remove-PatCollection {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Remove-PatCollectionItem.ps1
+++ b/PlexAutomationToolkit/Public/Remove-PatCollectionItem.ps1
@@ -27,6 +27,10 @@ function Remove-PatCollectionItem {
         One or more rating keys of the items to remove from the collection.
         Obtain these values from Get-PatCollection -IncludeItems.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -42,6 +46,11 @@ function Remove-PatCollectionItem {
         Remove-PatCollectionItem -CollectionId 12345 -RatingKey 67890
 
         Removes the item with rating key 67890 from collection 12345.
+
+    .EXAMPLE
+        Remove-PatCollectionItem -CollectionName 'Marvel' -LibraryName 'Movies' -RatingKey 67890 -ServerName 'Home'
+
+        Removes an item from a collection on the stored server named 'Home'.
 
     .EXAMPLE
         Remove-PatCollectionItem -CollectionName 'Marvel Movies' -LibraryName 'Movies' -RatingKey 111, 222
@@ -101,6 +110,10 @@ function Remove-PatCollectionItem {
         $RatingKey,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -118,7 +131,7 @@ function Remove-PatCollectionItem {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Remove-PatPlaylist.ps1
+++ b/PlexAutomationToolkit/Public/Remove-PatPlaylist.ps1
@@ -14,6 +14,10 @@ function Remove-PatPlaylist {
     .PARAMETER PlaylistName
         The name of the playlist to remove. Supports tab completion.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -29,6 +33,11 @@ function Remove-PatPlaylist {
         Remove-PatPlaylist -PlaylistId 12345
 
         Removes the playlist with ID 12345 after confirmation.
+
+    .EXAMPLE
+        Remove-PatPlaylist -PlaylistName 'Test Playlist' -ServerName 'Home' -Confirm:$false
+
+        Removes the playlist from the stored server named 'Home'.
 
     .EXAMPLE
         Remove-PatPlaylist -PlaylistName 'Old Playlist' -Confirm:$false
@@ -68,6 +77,10 @@ function Remove-PatPlaylist {
         $PlaylistName,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -85,7 +98,7 @@ function Remove-PatPlaylist {
 
     begin {
         try {
-            $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+            $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         }
         catch {
             throw "Failed to resolve server: $($_.Exception.Message)"

--- a/PlexAutomationToolkit/Public/Search-PatMedia.ps1
+++ b/PlexAutomationToolkit/Public/Search-PatMedia.ps1
@@ -11,6 +11,10 @@ function Search-PatMedia {
     .PARAMETER Query
         The search term to find matching media items.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400).
         If not specified, uses the default stored server.
@@ -79,6 +83,10 @@ function Search-PatMedia {
         $Query,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -111,7 +119,7 @@ function Search-PatMedia {
     )
 
     begin {
-        $script:serverContext = Resolve-PatServerContext -ServerUri $ServerUri -Token $Token
+        $script:serverContext = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
         $effectiveUri = $script:serverContext.Uri
         $headers = $script:serverContext.Headers
     }

--- a/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
+++ b/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
@@ -294,6 +294,10 @@ function Sync-PatMedia {
                     $null
                 }
 
+                if (-not $effectiveToken) {
+                    Write-Warning "No authentication token available. Downloads may fail with 401 Unauthorized errors. Use -Token parameter or configure a server with Add-PatServer."
+                }
+
                 $downloadCount = 0
                 $downloadedBytes = 0
                 $totalBytes = $syncPlan.BytesToDownload

--- a/PlexAutomationToolkit/Public/Test-PatLibraryPath.ps1
+++ b/PlexAutomationToolkit/Public/Test-PatLibraryPath.ps1
@@ -22,6 +22,10 @@ function Test-PatLibraryPath {
         Optional library section name (e.g., "Movies"). When provided, also
         validates that the path is under one of the section's configured root paths.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400)
         If not specified, uses the default stored server.
@@ -34,6 +38,11 @@ function Test-PatLibraryPath {
         Test-PatLibraryPath -Path '/mnt/media/Movies/NewMovie'
 
         Tests whether the path exists on the Plex server.
+
+    .EXAMPLE
+        Test-PatLibraryPath -Path '/mnt/media/Movies/NewMovie' -ServerName 'Home'
+
+        Tests whether the path exists on the stored server named 'Home'.
 
     .EXAMPLE
         Test-PatLibraryPath -Path '/mnt/media/Movies/NewMovie' -SectionName 'Movies'
@@ -77,6 +86,10 @@ function Test-PatLibraryPath {
         $SectionId,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -90,11 +103,14 @@ function Test-PatLibraryPath {
 
     # Build parameters for internal calls
     $serverParameters = @{}
-    if ($ServerUri) {
-        $serverParameters['ServerUri'] = $ServerUri
+    if ($ServerName) {
+        $serverParameters['ServerName'] = $ServerName
     }
-    if ($Token) {
-        $serverParameters['Token'] = $Token
+    elseif ($ServerUri) {
+        $serverParameters['ServerUri'] = $ServerUri
+        if ($Token) {
+            $serverParameters['Token'] = $Token
+        }
     }
 
     # If section is specified, validate path is under a configured root

--- a/PlexAutomationToolkit/Public/Test-PatServer.ps1
+++ b/PlexAutomationToolkit/Public/Test-PatServer.ps1
@@ -128,7 +128,7 @@ function Test-PatServer {
                 if ($errorMessage -match '\b401\b|Unauthorized') {
                     $isAuthError = $true
                 }
-                elseif ($errorMessage -match 'Unable to connect|ConnectFailure|NameResolutionFailure|timeout|unreachable|The remote name could not be resolved') {
+                elseif ($errorMessage -match 'Unable to connect|ConnectFailure|NameResolutionFailure|timed?\s*out|unreachable|The remote name could not be resolved') {
                     $isConnectionError = $true
                 }
             }

--- a/PlexAutomationToolkit/Public/Test-PatServer.ps1
+++ b/PlexAutomationToolkit/Public/Test-PatServer.ps1
@@ -1,0 +1,128 @@
+function Test-PatServer {
+    <#
+    .SYNOPSIS
+        Tests connectivity to a stored Plex server.
+
+    .DESCRIPTION
+        Validates that a stored server configuration works by attempting to connect
+        and authenticate with the Plex server. Returns connection status information
+        including whether the server is reachable, authenticated, and basic server details.
+
+    .PARAMETER Name
+        The name of the stored server to test. Use Get-PatStoredServer to see available servers.
+
+    .PARAMETER Quiet
+        If specified, returns only a boolean indicating success/failure instead of
+        detailed connection information.
+
+    .EXAMPLE
+        Test-PatServer -Name 'Home'
+
+        Tests connectivity to the stored server named 'Home' and returns detailed status.
+
+    .EXAMPLE
+        Test-PatServer -Name 'Home' -Quiet
+
+        Tests connectivity and returns $true if successful, $false otherwise.
+
+    .EXAMPLE
+        Get-PatStoredServer | ForEach-Object { Test-PatServer -Name $_.name }
+
+        Tests all stored servers and returns their connection status.
+
+    .EXAMPLE
+        if (Test-PatServer -Name 'Home' -Quiet) {
+            Get-PatLibrary -ServerName 'Home'
+        }
+
+        Checks server connectivity before attempting operations.
+
+    .OUTPUTS
+        PlexAutomationToolkit.ServerTestResult (default)
+        Returns an object with properties:
+        - Name: Server name from configuration
+        - Uri: The URI used for connection
+        - IsConnected: Whether the server responded
+        - IsAuthenticated: Whether authentication succeeded
+        - FriendlyName: Server's friendly name (if connected)
+        - Version: Plex server version (if connected)
+        - Error: Error message (if connection failed)
+
+        System.Boolean (with -Quiet)
+        Returns $true if connection succeeded, $false otherwise.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject], [bool])]
+    param (
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $Quiet
+    )
+
+    process {
+        $result = [PSCustomObject]@{
+            PSTypeName      = 'PlexAutomationToolkit.ServerTestResult'
+            Name            = $Name
+            Uri             = $null
+            IsConnected     = $false
+            IsAuthenticated = $false
+            FriendlyName    = $null
+            Version         = $null
+            Error           = $null
+        }
+
+        try {
+            # Get the stored server configuration
+            $server = Get-PatStoredServer -Name $Name -ErrorAction 'Stop'
+            $result.Uri = $server.uri
+
+            # Try to resolve context (this handles local/remote URI selection)
+            $serverContext = Resolve-PatServerContext -ServerName $Name -ErrorAction 'Stop'
+            $result.Uri = $serverContext.Uri
+
+            # Try to get server info
+            $uri = Join-PatUri -BaseUri $serverContext.Uri -Endpoint '/'
+            $serverInfo = Invoke-PatApi -Uri $uri -Headers $serverContext.Headers -ErrorAction 'Stop'
+
+            $result.IsConnected = $true
+            $result.IsAuthenticated = $true
+            $result.FriendlyName = $serverInfo.friendlyName
+            $result.Version = $serverInfo.version
+
+            Write-Verbose "Successfully connected to '$Name' at $($result.Uri)"
+        }
+        catch {
+            $errorMessage = $_.Exception.Message
+
+            # Try to determine if it's a connection issue vs auth issue
+            if ($errorMessage -match '401|Unauthorized') {
+                $result.IsConnected = $true
+                $result.IsAuthenticated = $false
+                $result.Error = 'Authentication failed - token may be invalid or expired'
+            }
+            elseif ($errorMessage -match 'Unable to connect|timeout|network|unreachable' -or
+                    $errorMessage -match 'The remote name could not be resolved') {
+                $result.IsConnected = $false
+                $result.IsAuthenticated = $false
+                $result.Error = "Server unreachable: $errorMessage"
+            }
+            else {
+                $result.Error = $errorMessage
+            }
+
+            Write-Verbose "Connection test failed for '$Name': $errorMessage"
+        }
+
+        if ($Quiet) {
+            $result.IsConnected -and $result.IsAuthenticated
+        }
+        else {
+            $result
+        }
+    }
+}

--- a/PlexAutomationToolkit/Public/Wait-PatLibraryScan.ps1
+++ b/PlexAutomationToolkit/Public/Wait-PatLibraryScan.ps1
@@ -25,6 +25,10 @@ function Wait-PatLibraryScan {
     .PARAMETER PassThru
         If specified, returns the final activity status when complete.
 
+    .PARAMETER ServerName
+        The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+        This is more convenient than ServerUri as you don't need to remember the URI or token.
+
     .PARAMETER ServerUri
         The base URI of the Plex server (e.g., http://plex.example.com:32400)
         If not specified, uses the default stored server.
@@ -38,6 +42,11 @@ function Wait-PatLibraryScan {
         Wait-PatLibraryScan -SectionName 'Movies'
 
         Triggers a library scan and waits for it to complete.
+
+    .EXAMPLE
+        Wait-PatLibraryScan -SectionName 'Movies' -ServerName 'Home'
+
+        Waits for a library scan on the stored server named 'Home'.
 
     .EXAMPLE
         Wait-PatLibraryScan -SectionId 2 -Timeout 60
@@ -86,6 +95,10 @@ function Wait-PatLibraryScan {
         $PassThru,
 
         [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName,
+
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({ Test-PatServerUri -Uri $_ })]
         [string]
@@ -99,11 +112,14 @@ function Wait-PatLibraryScan {
 
     # Build parameters for internal calls
     $serverParameters = @{}
-    if ($ServerUri) {
-        $serverParameters['ServerUri'] = $ServerUri
+    if ($ServerName) {
+        $serverParameters['ServerName'] = $ServerName
     }
-    if ($Token) {
-        $serverParameters['Token'] = $Token
+    elseif ($ServerUri) {
+        $serverParameters['ServerUri'] = $ServerUri
+        if ($Token) {
+            $serverParameters['Token'] = $Token
+        }
     }
 
     # Resolve section name to ID if needed

--- a/docs/en-US/Add-PatCollectionItem.md
+++ b/docs/en-US/Add-PatCollectionItem.md
@@ -14,20 +14,22 @@ Adds items to an existing collection on a Plex server.
 
 ### ById (Default)
 ```
-Add-PatCollectionItem -CollectionId <Int32> -RatingKey <Int32[]> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-PatCollectionItem -CollectionId <Int32> -RatingKey <Int32[]> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryId
 ```
-Add-PatCollectionItem -CollectionName <String> -LibraryId <Int32> -RatingKey <Int32[]> [-ServerUri <String>]
- [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-PatCollectionItem -CollectionName <String> -LibraryId <Int32> -RatingKey <Int32[]> [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryName
 ```
-Add-PatCollectionItem -CollectionName <String> -LibraryName <String> -RatingKey <Int32[]> [-ServerUri <String>]
- [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-PatCollectionItem -CollectionName <String> -LibraryName <String> -RatingKey <Int32[]>
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-PassThru]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -147,6 +149,22 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Add-PatPlaylistItem.md
+++ b/docs/en-US/Add-PatPlaylistItem.md
@@ -14,14 +14,14 @@ Adds items to an existing playlist on a Plex server.
 
 ### ById (Default)
 ```
-Add-PatPlaylistItem -PlaylistId <Int32> -RatingKey <Int32[]> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-PatPlaylistItem -PlaylistId <Int32> -RatingKey <Int32[]> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Add-PatPlaylistItem -PlaylistName <String> -RatingKey <Int32[]> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-PatPlaylistItem -PlaylistName <String> -RatingKey <Int32[]> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,6 +109,22 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Get-PatActivity.md
+++ b/docs/en-US/Get-PatActivity.md
@@ -13,8 +13,8 @@ Retrieves current activities from a Plex server.
 ## SYNTAX
 
 ```
-Get-PatActivity [[-Type] <String>] [[-SectionId] <Int32>] [[-ServerUri] <String>] [[-Token] <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatActivity [[-Type] <String>] [[-SectionId] <Int32>] [[-ServerName] <String>] [[-ServerUri] <String>]
+ [[-Token] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -100,6 +100,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400)
 If not specified, uses the default stored server.
@@ -110,7 +126,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -126,7 +142,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Get-PatCollection.md
+++ b/docs/en-US/Get-PatCollection.md
@@ -14,26 +14,26 @@ Retrieves collections from a Plex server library.
 
 ### All (Default)
 ```
-Get-PatCollection [-LibraryName <String>] [-LibraryId <Int32>] [-IncludeItems] [-ServerUri <String>]
- [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatCollection [-LibraryName <String>] [-LibraryId <Int32>] [-IncludeItems] [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatCollection -CollectionId <Int32> [-IncludeItems] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatCollection -CollectionId <Int32> [-IncludeItems] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryId
 ```
-Get-PatCollection -CollectionName <String> -LibraryId <Int32> [-IncludeItems] [-ServerUri <String>]
- [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatCollection -CollectionName <String> -LibraryId <Int32> [-IncludeItems] [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryName
 ```
-Get-PatCollection -CollectionName <String> -LibraryName <String> [-IncludeItems] [-ServerUri <String>]
- [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatCollection -CollectionName <String> -LibraryName <String> [-IncludeItems] [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -185,6 +185,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-PatLibrary.md
+++ b/docs/en-US/Get-PatLibrary.md
@@ -13,7 +13,7 @@ Retrieves Plex library information.
 ## SYNTAX
 
 ```
-Get-PatLibrary [[-ServerUri] <String>] [[-Token] <String>] [[-SectionId] <Int32>]
+Get-PatLibrary [[-ServerName] <String>] [[-ServerUri] <String>] [[-Token] <String>] [[-SectionId] <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -40,6 +40,22 @@ Use this to inspect a single library section when you already know its numeric I
 
 ## PARAMETERS
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400)
 If not specified, uses the default stored server.
@@ -50,7 +66,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -66,7 +82,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -82,7 +98,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: 0
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False

--- a/docs/en-US/Get-PatLibraryChildItem.md
+++ b/docs/en-US/Get-PatLibraryChildItem.md
@@ -14,20 +14,20 @@ Lists directories and files at a given path on the Plex server.
 
 ### PathOnly (Default)
 ```
-Get-PatLibraryChildItem [-Path <String>] [-ServerUri <String>] [-Token <String>]
+Get-PatLibraryChildItem [-Path <String>] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatLibraryChildItem [-Path <String>] [-SectionId <Int32>] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatLibraryChildItem [-Path <String>] [-SectionId <Int32>] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Get-PatLibraryChildItem [-Path <String>] [-SectionName <String>] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatLibraryChildItem [-Path <String>] [-SectionName <String>] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -102,6 +102,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-PatLibraryItem.md
+++ b/docs/en-US/Get-PatLibraryItem.md
@@ -14,13 +14,13 @@ Retrieves media items from a Plex library.
 
 ### ByName (Default)
 ```
-Get-PatLibraryItem -SectionName <String> [-ServerUri <String>] [-Token <String>]
+Get-PatLibraryItem -SectionName <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatLibraryItem -SectionId <Int32> [-ServerUri <String>] [-Token <String>]
+Get-PatLibraryItem -SectionId <Int32> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -80,6 +80,22 @@ Required: True
 Position: Named
 Default value: 0
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Get-PatLibraryPath.md
+++ b/docs/en-US/Get-PatLibraryPath.md
@@ -14,19 +14,19 @@ Retrieves library section paths from a Plex server.
 
 ### All (Default)
 ```
-Get-PatLibraryPath [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Get-PatLibraryPath [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Get-PatLibraryPath [-SectionName <String>] [-ServerUri <String>] [-Token <String>]
+Get-PatLibraryPath [-SectionName <String>] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatLibraryPath [-SectionId <Int32>] [-ServerUri <String>] [-Token <String>]
+Get-PatLibraryPath [-SectionId <Int32>] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -79,6 +79,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-PatMediaInfo.md
+++ b/docs/en-US/Get-PatMediaInfo.md
@@ -13,7 +13,7 @@ Retrieves detailed media information from a Plex server.
 ## SYNTAX
 
 ```
-Get-PatMediaInfo [-RatingKey] <Int32> [[-ServerUri] <String>] [[-Token] <String>]
+Get-PatMediaInfo [-RatingKey] <Int32> [[-ServerName] <String>] [[-ServerUri] <String>] [[-Token] <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -64,6 +64,22 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400).
 If not specified, uses the default stored server.
@@ -74,7 +90,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -90,7 +106,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Get-PatPlaylist.md
+++ b/docs/en-US/Get-PatPlaylist.md
@@ -14,20 +14,20 @@ Retrieves playlists from a Plex server.
 
 ### All (Default)
 ```
-Get-PatPlaylist [-IncludeItems] [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Get-PatPlaylist [-IncludeItems] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatPlaylist -PlaylistId <Int32> [-IncludeItems] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatPlaylist -PlaylistId <Int32> [-IncludeItems] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Get-PatPlaylist -PlaylistName <String> [-IncludeItems] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatPlaylist -PlaylistName <String> [-IncludeItems] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -118,6 +118,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Get-PatServer.md
+++ b/docs/en-US/Get-PatServer.md
@@ -13,8 +13,8 @@ Retrieves Plex server information.
 ## SYNTAX
 
 ```
-Get-PatServer [[-ServerUri] <String>] [[-Token] <String>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Get-PatServer [[-ServerName] <String>] [[-ServerUri] <String>] [[-Token] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,6 +39,22 @@ Handy for quickly confirming server version and platform details are reachable.
 
 ## PARAMETERS
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400)
 If not specified, uses the default stored server.
@@ -49,7 +65,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
@@ -65,7 +81,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Get-PatSession.md
+++ b/docs/en-US/Get-PatSession.md
@@ -13,8 +13,8 @@ Retrieves active playback sessions from a Plex server.
 ## SYNTAX
 
 ```
-Get-PatSession [[-Username] <String>] [[-Player] <String>] [[-ServerUri] <String>] [[-Token] <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatSession [[-Username] <String>] [[-Player] <String>] [[-ServerName] <String>] [[-ServerUri] <String>]
+ [[-Token] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -93,6 +93,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400).
 If not specified, uses the default stored server.
@@ -103,7 +119,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -119,7 +135,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Get-PatSyncPlan.md
+++ b/docs/en-US/Get-PatSyncPlan.md
@@ -14,14 +14,14 @@ Generates a sync plan for transferring media from a Plex playlist to a destinati
 
 ### ByName (Default)
 ```
-Get-PatSyncPlan [-PlaylistName <String>] -Destination <String> [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatSyncPlan [-PlaylistName <String>] -Destination <String> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Get-PatSyncPlan -PlaylistId <Int32> -Destination <String> [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-PatSyncPlan -PlaylistId <Int32> -Destination <String> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -88,6 +88,22 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/en-US/New-PatCollection.md
+++ b/docs/en-US/New-PatCollection.md
@@ -14,14 +14,16 @@ Creates a new collection in a Plex library.
 
 ### ByLibraryName (Default)
 ```
-New-PatCollection -Title <String> -LibraryName <String> -RatingKey <Int32[]> [-ServerUri <String>]
- [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PatCollection -Title <String> -LibraryName <String> -RatingKey <Int32[]> [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### ByLibraryId
 ```
-New-PatCollection -Title <String> -LibraryId <Int32> -RatingKey <Int32[]> [-ServerUri <String>]
- [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PatCollection -Title <String> -LibraryId <Int32> -RatingKey <Int32[]> [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -118,6 +120,22 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/New-PatPlaylist.md
+++ b/docs/en-US/New-PatPlaylist.md
@@ -13,8 +13,9 @@ Creates a new playlist on a Plex server.
 ## SYNTAX
 
 ```
-New-PatPlaylist [-Title] <String> [[-Type] <String>] [-RatingKey] <Int32[]> [[-ServerUri] <String>]
- [[-Token] <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PatPlaylist [-Title] <String> [[-Type] <String>] [-RatingKey] <Int32[]> [[-ServerName] <String>]
+ [[-ServerUri] <String>] [[-Token] <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -107,6 +108,22 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400).
 If not specified, uses the default stored server.
@@ -117,7 +134,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -133,7 +150,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Remove-PatCollection.md
+++ b/docs/en-US/Remove-PatCollection.md
@@ -14,20 +14,21 @@ Removes a collection from a Plex library.
 
 ### ById (Default)
 ```
-Remove-PatCollection -CollectionId <Int32> [-ServerUri <String>] [-Token <String>] [-PassThru]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatCollection -CollectionId <Int32> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryId
 ```
-Remove-PatCollection -CollectionName <String> -LibraryId <Int32> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatCollection -CollectionName <String> -LibraryId <Int32> [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryName
 ```
-Remove-PatCollection -CollectionName <String> -LibraryName <String> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatCollection -CollectionName <String> -LibraryName <String> [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -137,6 +138,22 @@ Aliases:
 Required: True
 Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Remove-PatCollectionItem.md
+++ b/docs/en-US/Remove-PatCollectionItem.md
@@ -14,21 +14,23 @@ Removes an item from a collection on a Plex server.
 
 ### ById (Default)
 ```
-Remove-PatCollectionItem -CollectionId <Int32> -RatingKey <Int32[]> [-ServerUri <String>] [-Token <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatCollectionItem -CollectionId <Int32> -RatingKey <Int32[]> [-ServerName <String>]
+ [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryId
 ```
-Remove-PatCollectionItem -CollectionName <String> -LibraryId <Int32> -RatingKey <Int32[]> [-ServerUri <String>]
- [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatCollectionItem -CollectionName <String> -LibraryId <Int32> -RatingKey <Int32[]>
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-PassThru]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByNameWithLibraryName
 ```
 Remove-PatCollectionItem -CollectionName <String> -LibraryName <String> -RatingKey <Int32[]>
- [-ServerUri <String>] [-Token <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-PassThru]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -159,6 +161,22 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Remove-PatPlaylist.md
+++ b/docs/en-US/Remove-PatPlaylist.md
@@ -14,14 +14,14 @@ Removes a playlist from a Plex server.
 
 ### ById (Default)
 ```
-Remove-PatPlaylist -PlaylistId <Int32> [-ServerUri <String>] [-Token <String>] [-PassThru]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatPlaylist -PlaylistId <Int32> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Remove-PatPlaylist -PlaylistName <String> [-ServerUri <String>] [-Token <String>] [-PassThru]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatPlaylist -PlaylistName <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -94,6 +94,22 @@ Parameter Sets: ByName
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/en-US/Remove-PatPlaylistItem.md
+++ b/docs/en-US/Remove-PatPlaylistItem.md
@@ -13,8 +13,9 @@ Removes an item from a playlist on a Plex server.
 ## SYNTAX
 
 ```
-Remove-PatPlaylistItem [-PlaylistId] <Int32> [-PlaylistItemId] <Int32> [[-ServerUri] <String>]
- [[-Token] <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PatPlaylistItem [-PlaylistId] <Int32> [-PlaylistItemId] <Int32> [[-ServerName] <String>]
+ [[-ServerUri] <String>] [[-Token] <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -93,6 +94,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400).
 If not specified, uses the default stored server.
@@ -103,7 +120,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -119,7 +136,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False

--- a/docs/en-US/Search-PatMedia.md
+++ b/docs/en-US/Search-PatMedia.md
@@ -14,20 +14,22 @@ Searches for media items across Plex libraries.
 
 ### All (Default)
 ```
-Search-PatMedia [-Query] <String> [-ServerUri <String>] [-Token <String>] [-Type <String[]>] [-Limit <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Search-PatMedia [-Query] <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-Type <String[]>] [-Limit <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Search-PatMedia [-Query] <String> [-ServerUri <String>] [-Token <String>] [-SectionName <String>]
- [-Type <String[]>] [-Limit <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Search-PatMedia [-Query] <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-SectionName <String>] [-Type <String[]>] [-Limit <Int32>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ### ById
 ```
-Search-PatMedia [-Query] <String> [-ServerUri <String>] [-Token <String>] [-SectionId <Int32>]
- [-Type <String[]>] [-Limit <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Search-PatMedia [-Query] <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
+ [-SectionId <Int32>] [-Type <String[]>] [-Limit <Int32>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -86,6 +88,22 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Stop-PatSession.md
+++ b/docs/en-US/Stop-PatSession.md
@@ -13,8 +13,8 @@ Terminates an active playback session on a Plex server.
 ## SYNTAX
 
 ```
-Stop-PatSession [-SessionId] <String> [[-Reason] <String>] [[-ServerUri] <String>] [[-Token] <String>]
- [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Stop-PatSession [-SessionId] <String> [[-Reason] <String>] [[-ServerName] <String>] [[-ServerUri] <String>]
+ [[-Token] <String>] [-PassThru] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -104,6 +104,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ServerUri
 The base URI of the Plex server (e.g., http://plex.example.com:32400).
 If not specified, uses the default stored server.
@@ -114,7 +130,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -130,7 +146,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Sync-PatMedia.md
+++ b/docs/en-US/Sync-PatMedia.md
@@ -15,7 +15,7 @@ Syncs media from a Plex playlist to a destination folder.
 ### ByName (Default)
 ```
 Sync-PatMedia [-PlaylistName <String>] -Destination <String> [-SkipSubtitles] [-SkipRemoval] [-Force]
- [-PassThru] [-ServerUri <String>] [-Token <String>] [-SyncWatchStatus] [-RemoveWatched]
+ [-PassThru] [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-SyncWatchStatus] [-RemoveWatched]
  [-SourceServerName <String>] [-TargetServerName <String>] [-ProgressAction <ActionPreference>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
@@ -23,8 +23,9 @@ Sync-PatMedia [-PlaylistName <String>] -Destination <String> [-SkipSubtitles] [-
 ### ById
 ```
 Sync-PatMedia -PlaylistId <Int32> -Destination <String> [-SkipSubtitles] [-SkipRemoval] [-Force] [-PassThru]
- [-ServerUri <String>] [-Token <String>] [-SyncWatchStatus] [-RemoveWatched] [-SourceServerName <String>]
- [-TargetServerName <String>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-SyncWatchStatus] [-RemoveWatched]
+ [-SourceServerName <String>] [-TargetServerName <String>] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -161,6 +162,23 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use for the source media. Use Get-PatStoredServer to see
+available servers. This is more convenient than ServerUri as you don't need to remember
+the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Test-PatLibraryPath.md
+++ b/docs/en-US/Test-PatLibraryPath.md
@@ -14,20 +14,20 @@ Tests whether a path exists on the Plex server's filesystem.
 
 ### PathOnly (Default)
 ```
-Test-PatLibraryPath [-Path] <String> [-ServerUri <String>] [-Token <String>]
+Test-PatLibraryPath [-Path] <String> [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ByName
 ```
-Test-PatLibraryPath [-Path] <String> [-SectionName <String>] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-PatLibraryPath [-Path] <String> [-SectionName <String>] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ById
 ```
-Test-PatLibraryPath [-Path] <String> [-SectionId <Int32>] [-ServerUri <String>] [-Token <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-PatLibraryPath [-Path] <String> [-SectionId <Int32>] [-ServerName <String>] [-ServerUri <String>]
+ [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -119,6 +119,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Test-PatServer.md
+++ b/docs/en-US/Test-PatServer.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProgressAction
-{{ Fill ProgressAction Description }}
+Determines how the cmdlet responds to progress updates. This is a common parameter.
 
 ```yaml
 Type: ActionPreference

--- a/docs/en-US/Test-PatServer.md
+++ b/docs/en-US/Test-PatServer.md
@@ -1,0 +1,126 @@
+---
+external help file: PlexAutomationToolkit-help.xml
+Module Name: PlexAutomationToolkit
+online version:
+schema: 2.0.0
+---
+
+# Test-PatServer
+
+## SYNOPSIS
+Tests connectivity to a stored Plex server.
+
+## SYNTAX
+
+```
+Test-PatServer [-Name] <String> [-Quiet] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Validates that a stored server configuration works by attempting to connect
+and authenticate with the Plex server.
+Returns connection status information
+including whether the server is reachable, authenticated, and basic server details.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Test-PatServer -Name 'Home'
+```
+
+Tests connectivity to the stored server named 'Home' and returns detailed status.
+
+### EXAMPLE 2
+```
+Test-PatServer -Name 'Home' -Quiet
+```
+
+Tests connectivity and returns $true if successful, $false otherwise.
+
+### EXAMPLE 3
+```
+Get-PatStoredServer | ForEach-Object { Test-PatServer -Name $_.name }
+```
+
+Tests all stored servers and returns their connection status.
+
+### EXAMPLE 4
+```
+if (Test-PatServer -Name 'Home' -Quiet) {
+    Get-PatLibrary -ServerName 'Home'
+}
+```
+
+Checks server connectivity before attempting operations.
+
+## PARAMETERS
+
+### -Name
+The name of the stored server to test.
+Use Get-PatStoredServer to see available servers.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Quiet
+If specified, returns only a boolean indicating success/failure instead of
+detailed connection information.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PlexAutomationToolkit.ServerTestResult (default)
+### Returns an object with properties:
+### - Name: Server name from configuration
+### - Uri: The URI used for connection
+### - IsConnected: Whether the server responded
+### - IsAuthenticated: Whether authentication succeeded
+### - FriendlyName: Server's friendly name (if connected)
+### - Version: Plex server version (if connected)
+### - Error: Error message (if connection failed)
+### System.Boolean (with -Quiet)
+### Returns $true if connection succeeded, $false otherwise.
+## NOTES
+
+## RELATED LINKS

--- a/docs/en-US/Update-PatLibrary.md
+++ b/docs/en-US/Update-PatLibrary.md
@@ -15,14 +15,14 @@ Refreshes a Plex library section.
 ### ByName (Default)
 ```
 Update-PatLibrary -SectionName <String> [-Path <String>] [-PassThru] [-SkipPathValidation] [-Wait]
- [-Timeout <Int32>] [-ReportChanges] [-ServerUri <String>] [-Token <String>]
+ [-Timeout <Int32>] [-ReportChanges] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ById
 ```
 Update-PatLibrary -SectionId <Int32> [-Path <String>] [-PassThru] [-SkipPathValidation] [-Wait]
- [-Timeout <Int32>] [-ReportChanges] [-ServerUri <String>] [-Token <String>]
+ [-Timeout <Int32>] [-ReportChanges] [-ServerName <String>] [-ServerUri <String>] [-Token <String>]
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -209,6 +209,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Wait-PatLibraryScan.md
+++ b/docs/en-US/Wait-PatLibraryScan.md
@@ -15,13 +15,15 @@ Waits for a Plex library scan to complete.
 ### ByName (Default)
 ```
 Wait-PatLibraryScan -SectionName <String> [-Timeout <Int32>] [-PollingInterval <Int32>] [-PassThru]
- [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ### ById
 ```
 Wait-PatLibraryScan -SectionId <Int32> [-Timeout <Int32>] [-PollingInterval <Int32>] [-PassThru]
- [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-ServerName <String>] [-ServerUri <String>] [-Token <String>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -138,6 +140,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServerName
+The name of a stored server to use. Use Get-PatStoredServer to see available servers.
+This is more convenient than ServerUri as you don't need to remember the URI or token.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/tests/Integration/IntegrationTestHelpers.psm1
+++ b/tests/Integration/IntegrationTestHelpers.psm1
@@ -41,7 +41,7 @@ function Get-IntegrationTestContext {
         Token           = $env:PLEX_TOKEN
         TestSectionId   = $env:PLEX_TEST_SECTION_ID
         TestSectionName = $env:PLEX_TEST_SECTION_NAME
-        AllowMutations  = ($env:PLEX_ALLOW_MUTATIONS -eq 'true')
+        AllowLibraryRefresh = ($env:PLEX_ALLOW_LIBRARY_REFRESH -eq 'true')
     }
 }
 

--- a/tests/Integration/Public/Collection.Integration.tests.ps1
+++ b/tests/Integration/Public/Collection.Integration.tests.ps1
@@ -1,19 +1,10 @@
 BeforeDiscovery {
     # Check if integration tests should run
     $script:integrationEnabled = $false
-    $script:mutationTestsEnabled = $false
 
     if ($env:PLEX_SERVER_URI -and $env:PLEX_TOKEN) {
         $script:integrationEnabled = $true
         Write-Host "Collection integration tests ENABLED - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
-
-        if ($env:PLEX_ALLOW_MUTATIONS -eq 'true') {
-            $script:mutationTestsEnabled = $true
-            Write-Host "Mutation tests ENABLED - Collections will be created/modified" -ForegroundColor Yellow
-        }
-        else {
-            Write-Host "Mutation tests DISABLED - Set PLEX_ALLOW_MUTATIONS=true to enable" -ForegroundColor Yellow
-        }
     }
     else {
         $missingVars = @()
@@ -174,7 +165,7 @@ Describe 'Get-PatCollection Integration Tests' -Skip:(-not $script:integrationEn
     }
 }
 
-Describe 'Collection CRUD Integration Tests' -Skip:(-not $script:mutationTestsEnabled) {
+Describe 'Collection CRUD Integration Tests' -Skip:(-not $script:integrationEnabled) {
 
     BeforeAll {
         # Backup and setup test server

--- a/tests/Integration/Public/LibraryOperations.Integration.tests.ps1
+++ b/tests/Integration/Public/LibraryOperations.Integration.tests.ps1
@@ -1,19 +1,19 @@
 BeforeDiscovery {
     # Check if integration tests should run
     $script:integrationEnabled = $false
-    $script:mutationsEnabled = $false
+    $script:libraryRefreshEnabled = $false
 
     if ($env:PLEX_SERVER_URI -and $env:PLEX_TOKEN) {
         $script:integrationEnabled = $true
 
-        if ($env:PLEX_ALLOW_MUTATIONS -eq 'true') {
-            $script:mutationsEnabled = $true
-            Write-Host "Integration tests ENABLED with MUTATIONS - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
-            Write-Host "WARNING: Mutation tests will trigger library refresh operations on your Plex server" -ForegroundColor Yellow
+        if ($env:PLEX_ALLOW_LIBRARY_REFRESH -eq 'true') {
+            $script:libraryRefreshEnabled = $true
+            Write-Host "Integration tests ENABLED with LIBRARY REFRESH - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
+            Write-Host "WARNING: Library refresh tests will trigger scan operations on your Plex server" -ForegroundColor Yellow
         }
         else {
-            Write-Host "Integration tests ENABLED (mutations disabled) - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
-            Write-Host "Set PLEX_ALLOW_MUTATIONS='true' to enable mutation tests (library refresh operations)" -ForegroundColor Cyan
+            Write-Host "Integration tests ENABLED (library refresh disabled) - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
+            Write-Host "Set PLEX_ALLOW_LIBRARY_REFRESH='true' to enable library refresh tests" -ForegroundColor Cyan
         }
     }
     else {
@@ -87,7 +87,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
         }
     }
 
-    Context 'Library refresh by section ID' -Skip:(-not $script:mutationsEnabled) {
+    Context 'Library refresh by section ID' -Skip:(-not $script:libraryRefreshEnabled) {
 
         It 'Successfully refreshes library by section ID' {
             { Update-PatLibrary -SectionId $script:testSectionId -Confirm:$false } | Should -Not -Throw
@@ -107,7 +107,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
         }
     }
 
-    Context 'Library refresh by section name' -Skip:(-not $script:mutationsEnabled) {
+    Context 'Library refresh by section name' -Skip:(-not $script:libraryRefreshEnabled) {
 
         It 'Successfully refreshes library by section name' {
             { Update-PatLibrary -SectionName $script:testSectionName -Confirm:$false } | Should -Not -Throw
@@ -118,7 +118,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
         }
     }
 
-    Context 'Library refresh with specific path' -Skip:(-not $script:mutationsEnabled) {
+    Context 'Library refresh with specific path' -Skip:(-not $script:libraryRefreshEnabled) {
 
         It 'Successfully refreshes library with specific path by section ID' {
             # This tests path-based refresh - using SkipPathValidation since we're testing parameter handling
@@ -135,7 +135,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
         }
     }
 
-    Context 'Using explicit ServerUri parameter' -Skip:(-not $script:mutationsEnabled) {
+    Context 'Using explicit ServerUri parameter' -Skip:(-not $script:libraryRefreshEnabled) {
 
         It 'Works with explicit ServerUri and Token parameters' {
             # Tests the -Token parameter which allows explicit ServerUri to work with authentication
@@ -165,7 +165,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
         }
     }
 
-    Context 'ShouldProcess confirmation behavior' -Skip:(-not $script:mutationsEnabled) {
+    Context 'ShouldProcess confirmation behavior' -Skip:(-not $script:libraryRefreshEnabled) {
 
         It 'Respects -Confirm:$false parameter' {
             # Should execute without prompting
@@ -206,7 +206,7 @@ Describe 'Update-PatLibrary Integration Tests' -Skip:(-not $script:integrationEn
             }
         }
 
-        It 'Update-PatLibrary validates path without -SkipPathValidation' -Skip:(-not $script:mutationsEnabled) {
+        It 'Update-PatLibrary validates path without -SkipPathValidation' -Skip:(-not $script:libraryRefreshEnabled) {
             # Get library paths to find which section contains our test path
             $libraryPaths = Get-PatLibraryPath
             $matchingSection = $libraryPaths | Where-Object {

--- a/tests/Integration/Public/MediaSync.Integration.tests.ps1
+++ b/tests/Integration/Public/MediaSync.Integration.tests.ps1
@@ -1,19 +1,10 @@
 BeforeDiscovery {
     # Check if integration tests should run
     $script:integrationEnabled = $false
-    $script:syncTestsEnabled = $false
 
     if ($env:PLEX_SERVER_URI -and $env:PLEX_TOKEN) {
         $script:integrationEnabled = $true
         Write-Host "Media sync integration tests ENABLED - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
-
-        if ($env:PLEX_ALLOW_MUTATIONS -eq 'true') {
-            $script:syncTestsEnabled = $true
-            Write-Host "Sync tests ENABLED - Files will be downloaded to temp directory" -ForegroundColor Yellow
-        }
-        else {
-            Write-Host "Sync tests DISABLED - Set PLEX_ALLOW_MUTATIONS=true to enable" -ForegroundColor Yellow
-        }
     }
     else {
         $missingVars = @()
@@ -195,7 +186,7 @@ Describe 'Get-PatSyncPlan Integration Tests' -Skip:(-not $script:integrationEnab
     }
 }
 
-Describe 'Sync-PatMedia Integration Tests' -Skip:(-not $script:syncTestsEnabled) {
+Describe 'Sync-PatMedia Integration Tests' -Skip:(-not $script:integrationEnabled) {
 
     BeforeAll {
         # Setup test server

--- a/tests/Integration/Public/Playlist.Integration.tests.ps1
+++ b/tests/Integration/Public/Playlist.Integration.tests.ps1
@@ -1,19 +1,10 @@
 BeforeDiscovery {
     # Check if integration tests should run
     $script:integrationEnabled = $false
-    $script:mutationTestsEnabled = $false
 
     if ($env:PLEX_SERVER_URI -and $env:PLEX_TOKEN) {
         $script:integrationEnabled = $true
         Write-Host "Playlist integration tests ENABLED - Testing against: $env:PLEX_SERVER_URI" -ForegroundColor Green
-
-        if ($env:PLEX_ALLOW_MUTATIONS -eq 'true') {
-            $script:mutationTestsEnabled = $true
-            Write-Host "Mutation tests ENABLED - Playlists will be created/modified" -ForegroundColor Yellow
-        }
-        else {
-            Write-Host "Mutation tests DISABLED - Set PLEX_ALLOW_MUTATIONS=true to enable" -ForegroundColor Yellow
-        }
     }
     else {
         $missingVars = @()
@@ -122,7 +113,7 @@ Describe 'Get-PatPlaylist Integration Tests' -Skip:(-not $script:integrationEnab
     }
 }
 
-Describe 'Playlist CRUD Integration Tests' -Skip:(-not $script:mutationTestsEnabled) {
+Describe 'Playlist CRUD Integration Tests' -Skip:(-not $script:integrationEnabled) {
 
     BeforeAll {
         # Backup and setup test server

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -36,7 +36,7 @@ Integration tests verify PlexAutomationToolkit against a real Plex server. These
 ### Optional
 - `PLEX_TEST_SECTION_ID` - Specific section ID to test (discovered dynamically if not set)
 - `PLEX_TEST_SECTION_NAME` - Specific section name to test (discovered dynamically if not set)
-- `PLEX_ALLOW_MUTATIONS` - Set to `'true'` to enable tests that trigger library refresh
+- `PLEX_ALLOW_LIBRARY_REFRESH` - Set to `'true'` to enable tests that trigger library scan operations
 
 ## CI/CD Setup (GitHub Actions)
 
@@ -70,10 +70,17 @@ Tests in this category use dynamic discovery and work with any Plex server confi
 
 Tests use temporary entries with "IntegrationTest-" prefix and always clean up after completion.
 
-### Mutating Tests (Require `PLEX_ALLOW_MUTATIONS=true`)
-- Library refresh operations
+### CRUD Tests (Run by Default - Safe with Cleanup)
+- Collection create/read/update/delete
+- Playlist create/read/update/delete
+- Media sync (downloads to temp directory)
 
-These tests trigger server work (scanning for new content). Set `$env:PLEX_ALLOW_MUTATIONS = 'true'` to enable.
+These tests create temporary resources tracked in memory and automatically cleaned up in AfterAll blocks. They run by default because cleanup is reliable.
+
+### Library Refresh Tests (Require `PLEX_ALLOW_LIBRARY_REFRESH=true`)
+- Library scan/refresh operations
+
+These tests trigger server-side background tasks that cannot be undone. Set `$env:PLEX_ALLOW_LIBRARY_REFRESH = 'true'` to enable.
 
 ## Troubleshooting
 

--- a/tests/Unit/Private/Remove-PatServerToken.tests.ps1
+++ b/tests/Unit/Private/Remove-PatServerToken.tests.ps1
@@ -103,7 +103,7 @@ Describe 'Remove-PatServerToken' {
             # that when the secret exists, an attempt is made (which fails with a warning)
             InModuleScope PlexAutomationToolkit {
                 Mock Get-PatSecretManagementAvailable { $true }
-                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer' } }
+                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer'; Vault = 'PlexSecrets' } }
 
                 $warnings = Remove-PatServerToken -ServerName 'TestServer' 3>&1
                 # When Remove-Secret is called but fails (not properly mocked), we get a warning
@@ -130,7 +130,7 @@ Describe 'Remove-PatServerToken' {
         It 'Catches the error and emits a warning' {
             InModuleScope PlexAutomationToolkit {
                 Mock Get-PatSecretManagementAvailable { $true }
-                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer' } }
+                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer'; Vault = 'PlexSecrets' } }
                 Mock Remove-Secret { throw 'Vault access denied' }
 
                 $warnings = Remove-PatServerToken -ServerName 'TestServer' 3>&1
@@ -142,7 +142,7 @@ Describe 'Remove-PatServerToken' {
         It 'Does not throw' {
             InModuleScope PlexAutomationToolkit {
                 Mock Get-PatSecretManagementAvailable { $true }
-                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer' } }
+                Mock Get-SecretInfo { [PSCustomObject]@{ Name = 'PlexAutomationToolkit/TestServer'; Vault = 'PlexSecrets' } }
                 Mock Remove-Secret { throw 'Vault access denied' }
 
                 { Remove-PatServerToken -ServerName 'TestServer' } | Should -Not -Throw

--- a/tests/Unit/Private/Resolve-PatServerContext.tests.ps1
+++ b/tests/Unit/Private/Resolve-PatServerContext.tests.ps1
@@ -101,8 +101,16 @@ Describe 'Resolve-PatServerContext' {
             }
         }
 
-        It 'Should propagate the error' {
+        It 'Should throw with helpful error message including original error' {
+            { Resolve-PatServerContext } | Should -Throw '*No server specified and failed to retrieve default server*'
+        }
+
+        It 'Should include original error details' {
             { Resolve-PatServerContext } | Should -Throw '*Config file not found*'
+        }
+
+        It 'Should suggest alternatives in error message' {
+            { Resolve-PatServerContext } | Should -Throw '*-ServerName*-ServerUri*Add-PatServer*'
         }
     }
 

--- a/tests/Unit/Private/Resolve-PatServerContext.tests.ps1
+++ b/tests/Unit/Private/Resolve-PatServerContext.tests.ps1
@@ -105,4 +105,70 @@ Describe 'Resolve-PatServerContext' {
             { Resolve-PatServerContext } | Should -Throw '*Config file not found*'
         }
     }
+
+    Context 'When ServerName is provided' {
+        BeforeEach {
+            function Get-PatStoredServer { }
+            function Select-PatServerUri { }
+
+            Mock Get-PatStoredServer {
+                [PSCustomObject]@{
+                    name    = 'Home'
+                    uri     = 'http://home:32400'
+                    token   = 'home-token-123'
+                    default = $false
+                }
+            }
+
+            Mock Select-PatServerUri {
+                [PSCustomObject]@{
+                    Uri     = 'http://home:32400'
+                    IsLocal = $false
+                    SelectionReason = 'Primary URI selected'
+                }
+            }
+        }
+
+        It 'Should return context with named server URI' {
+            $ctx = Resolve-PatServerContext -ServerName 'Home'
+
+            $ctx.Uri | Should -Be 'http://home:32400'
+            $ctx.WasExplicitUri | Should -Be $false
+            $ctx.Server | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should return headers with authentication from named server' {
+            $ctx = Resolve-PatServerContext -ServerName 'Home'
+
+            $ctx.Headers['Accept'] | Should -Be 'application/json'
+            $ctx.Headers['X-Plex-Token'] | Should -Be 'home-token-123'
+        }
+
+        It 'Should return server name in context' {
+            $ctx = Resolve-PatServerContext -ServerName 'Home'
+
+            $ctx.Server.name | Should -Be 'Home'
+        }
+    }
+
+    Context 'When both ServerName and ServerUri are provided' {
+        It 'Should throw an error' {
+            { Resolve-PatServerContext -ServerName 'Home' -ServerUri 'http://explicit:32400' } |
+                Should -Throw '*Cannot specify both -ServerName and -ServerUri*'
+        }
+    }
+
+    Context 'When named server is not found' {
+        BeforeEach {
+            function Get-PatStoredServer { }
+            Mock Get-PatStoredServer {
+                throw "Server 'NonExistent' not found"
+            }
+        }
+
+        It 'Should throw an error' {
+            { Resolve-PatServerContext -ServerName 'NonExistent' } |
+                Should -Throw "*Server 'NonExistent' not found*"
+        }
+    }
 }

--- a/tests/Unit/Public/Get-PatLibraryItem.tests.ps1
+++ b/tests/Unit/Public/Get-PatLibraryItem.tests.ps1
@@ -447,7 +447,7 @@ Describe 'Get-PatLibraryItem' {
         }
 
         It 'Throws wrapped error message' {
-            { Get-PatLibraryItem -SectionId 2 } | Should -Throw '*Failed to get default server*'
+            { Get-PatLibraryItem -SectionId 2 } | Should -Throw '*Failed to resolve server*'
         }
     }
 

--- a/tests/Unit/Public/Get-PatServer.tests.ps1
+++ b/tests/Unit/Public/Get-PatServer.tests.ps1
@@ -149,12 +149,12 @@ Describe 'Get-PatServer' {
             { Get-PatServer } | Should -Throw "*Failed to resolve server*"
         }
 
-        It 'Should cache default server for performance' {
+        It 'Should resolve server for each call' {
             Get-PatServer
             Get-PatServer
 
-            # Should only call Get-PatStoredServer once in begin block
-            Should -Invoke Get-PatStoredServer -ModuleName PlexAutomationToolkit -Times 1
+            # Each call resolves server independently (caching only applies within a single pipeline invocation)
+            Should -Invoke Get-PatStoredServer -ModuleName PlexAutomationToolkit -Times 2
         }
     }
 

--- a/tests/Unit/Public/Get-PatServer.tests.ps1
+++ b/tests/Unit/Public/Get-PatServer.tests.ps1
@@ -146,7 +146,7 @@ Describe 'Get-PatServer' {
                 throw 'Config error'
             }
 
-            { Get-PatServer } | Should -Throw "*Failed to get default server*"
+            { Get-PatServer } | Should -Throw "*Failed to resolve server*"
         }
 
         It 'Should cache default server for performance' {

--- a/tests/Unit/Public/Get-PatSyncPlan.tests.ps1
+++ b/tests/Unit/Public/Get-PatSyncPlan.tests.ps1
@@ -920,7 +920,7 @@ Describe 'Get-PatSyncPlan' {
 
         It 'Throws with context when Get-PatStoredServer fails' {
             { Get-PatSyncPlan -Destination $script:TestDir } |
-                Should -Throw "*Failed to get default server*"
+                Should -Throw "*Failed to resolve server*"
         }
     }
 

--- a/tests/Unit/Public/Test-PatServer.tests.ps1
+++ b/tests/Unit/Public/Test-PatServer.tests.ps1
@@ -184,6 +184,135 @@ Describe 'Test-PatServer' {
         }
     }
 
+    Context 'Error categorization with WebException' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Categorizes WebException ConnectFailure as connection error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                $innerEx = [System.Net.WebException]::new(
+                    'Unable to connect to remote server',
+                    [System.Net.WebExceptionStatus]::ConnectFailure
+                )
+                $ex = [System.Exception]::new('Connection failed', $innerEx)
+                throw $ex
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $false
+            $result.Error | Should -Match 'unreachable'
+        }
+
+        It 'Categorizes WebException NameResolutionFailure as connection error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                $innerEx = [System.Net.WebException]::new(
+                    'The remote name could not be resolved',
+                    [System.Net.WebExceptionStatus]::NameResolutionFailure
+                )
+                $ex = [System.Exception]::new('DNS failed', $innerEx)
+                throw $ex
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $false
+            $result.Error | Should -Match 'unreachable'
+        }
+
+        It 'Categorizes WebException Timeout as connection error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                $innerEx = [System.Net.WebException]::new(
+                    'The operation has timed out',
+                    [System.Net.WebExceptionStatus]::Timeout
+                )
+                $ex = [System.Exception]::new('Timeout', $innerEx)
+                throw $ex
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $false
+            $result.Error | Should -Match 'unreachable'
+        }
+    }
+
+    Context 'Error categorization with pattern matching fallback' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Categorizes error with Unauthorized text as auth error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                throw 'Request returned Unauthorized status'
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $true
+            $result.IsAuthenticated | Should -Be $false
+            $result.Error | Should -Match 'Authentication'
+        }
+
+        It 'Categorizes error with 401 status code as auth error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                throw 'The remote server returned an error: (401) Not Authorized'
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $true
+            $result.IsAuthenticated | Should -Be $false
+        }
+
+        It 'Categorizes error with timeout text as connection error' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                throw 'The request timed out after 30 seconds'
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $false
+            $result.Error | Should -Match 'unreachable'
+        }
+
+        It 'Preserves original error for unknown error types' {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                throw 'Unexpected server error: disk full'
+            }
+
+            $result = Test-PatServer -Name 'Home'
+            $result.Error | Should -Match 'disk full'
+        }
+    }
+
     Context 'Output type' {
         BeforeAll {
             Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {

--- a/tests/Unit/Public/Test-PatServer.tests.ps1
+++ b/tests/Unit/Public/Test-PatServer.tests.ps1
@@ -1,0 +1,222 @@
+BeforeAll {
+    # Import the module from source
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+}
+
+Describe 'Test-PatServer' {
+
+    BeforeAll {
+        # Mock server configuration
+        $script:mockServer = @{
+            name    = 'Home'
+            uri     = 'http://plex.local:32400'
+            default = $true
+        }
+
+        # Mock successful server response
+        $script:mockServerInfo = @{
+            friendlyName = 'My Plex Server'
+            version      = '1.32.0.0'
+            platform     = 'Linux'
+        }
+    }
+
+    Context 'When server is reachable and authenticated' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json'; 'X-Plex-Token' = 'test-token' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $script:mockServerInfo
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Returns successful test result' {
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $true
+            $result.IsAuthenticated | Should -Be $true
+        }
+
+        It 'Returns server details when connected' {
+            $result = Test-PatServer -Name 'Home'
+            $result.FriendlyName | Should -Be 'My Plex Server'
+            $result.Version | Should -Be '1.32.0.0'
+        }
+
+        It 'Returns true with -Quiet switch' {
+            $result = Test-PatServer -Name 'Home' -Quiet
+            $result | Should -Be $true
+        }
+
+        It 'Returns no error when successful' {
+            $result = Test-PatServer -Name 'Home'
+            $result.Error | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When server is unreachable' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                throw 'Unable to connect to server'
+            }
+        }
+
+        It 'Returns unsuccessful test result' {
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $false
+            $result.IsAuthenticated | Should -Be $false
+        }
+
+        It 'Returns false with -Quiet switch' {
+            $result = Test-PatServer -Name 'Home' -Quiet
+            $result | Should -Be $false
+        }
+
+        It 'Returns error message' {
+            $result = Test-PatServer -Name 'Home'
+            $result.Error | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'When authentication fails' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                throw '401 Unauthorized'
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Returns connected but not authenticated' {
+            $result = Test-PatServer -Name 'Home'
+            $result.IsConnected | Should -Be $true
+            $result.IsAuthenticated | Should -Be $false
+        }
+
+        It 'Returns authentication error message' {
+            $result = Test-PatServer -Name 'Home'
+            $result.Error | Should -Match 'Authentication'
+        }
+    }
+
+    Context 'When server not found in configuration' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                throw "Server 'NonExistent' not found"
+            }
+        }
+
+        It 'Returns error when server not found' {
+            $result = Test-PatServer -Name 'NonExistent'
+            $result.IsConnected | Should -Be $false
+            $result.Error | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'With pipeline input' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json'; 'X-Plex-Token' = 'test-token' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $script:mockServerInfo
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Accepts server name from pipeline' {
+            $result = 'Home' | Test-PatServer
+            $result.Name | Should -Be 'Home'
+        }
+    }
+
+    Context 'Output type' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                return $script:mockServer
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return @{
+                    Uri               = 'http://plex.local:32400'
+                    Headers           = @{ Accept = 'application/json'; 'X-Plex-Token' = 'test-token' }
+                    WasExplicitUri    = $false
+                    Server            = $script:mockServer
+                    IsLocalConnection = $false
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $script:mockServerInfo
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://plex.local:32400/'
+            }
+        }
+
+        It 'Returns PlexAutomationToolkit.ServerTestResult type' {
+            $result = Test-PatServer -Name 'Home'
+            $result.PSObject.TypeNames | Should -Contain 'PlexAutomationToolkit.ServerTestResult'
+        }
+
+        It 'Returns boolean with -Quiet' {
+            $result = Test-PatServer -Name 'Home' -Quiet
+            $result.GetType().Name | Should -Be 'Boolean'
+        }
+    }
+}

--- a/tests/Unit/Public/Update-PatLibrary.tests.ps1
+++ b/tests/Unit/Public/Update-PatLibrary.tests.ps1
@@ -538,7 +538,7 @@ Describe 'Update-PatLibrary' {
         }
 
         It 'Throws with server error context' {
-            { Update-PatLibrary -SectionId 2 -Confirm:$false } | Should -Throw '*Failed to get default server*'
+            { Update-PatLibrary -SectionId 2 -Confirm:$false } | Should -Throw '*Failed to resolve server*'
         }
     }
 

--- a/tests/Unit/Public/Update-PatLibrary.tests.ps1
+++ b/tests/Unit/Public/Update-PatLibrary.tests.ps1
@@ -700,6 +700,165 @@ Describe 'Update-PatLibrary' {
         }
     }
 
+    Context 'When using ServerName parameter' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                param($Name, $Default)
+                if ($Name -eq 'HomeServer') {
+                    return [PSCustomObject]@{
+                        name    = 'HomeServer'
+                        uri     = 'http://home.test:32400'
+                        token   = 'home-token'
+                        default = $false
+                    }
+                }
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatAuthenticationHeader {
+                return @{
+                    Accept         = 'application/json'
+                    'X-Plex-Token' = 'home-token'
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://home.test:32400/library/sections/2/refresh'
+            }
+        }
+
+        It 'Uses the named server for refresh' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionId 2 -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Get-PatStoredServer -ParameterFilter {
+                $Name -eq 'HomeServer'
+            }
+        }
+
+        It 'Calls Join-PatUri with named server URI' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionId 2 -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Join-PatUri -ParameterFilter {
+                $BaseUri -eq 'http://home.test:32400'
+            }
+        }
+
+        It 'Uses Get-PatAuthenticationHeader for named server' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionId 2 -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Get-PatAuthenticationHeader -ParameterFilter {
+                $Server.name -eq 'HomeServer'
+            }
+        }
+    }
+
+    Context 'When using ServerName with SectionName' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                param($Name, $Default)
+                if ($Name -eq 'HomeServer') {
+                    return [PSCustomObject]@{
+                        name    = 'HomeServer'
+                        uri     = 'http://home.test:32400'
+                        token   = 'home-token'
+                        default = $false
+                    }
+                }
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatAuthenticationHeader {
+                return @{
+                    Accept         = 'application/json'
+                    'X-Plex-Token' = 'home-token'
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatLibrary {
+                return @{
+                    Directory = @(
+                        @{ key = '2'; title = 'Movies' }
+                        @{ key = '3'; title = 'TV Shows' }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                param($BaseUri, $Endpoint, $QueryString)
+                return "$BaseUri$Endpoint"
+            }
+        }
+
+        It 'Passes ServerName to Get-PatLibrary for section name resolution' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionName 'Movies' -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Get-PatLibrary -ParameterFilter {
+                $ServerName -eq 'HomeServer'
+            }
+        }
+
+        It 'Does not pass ServerUri when using ServerName' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionName 'Movies' -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Get-PatLibrary -ParameterFilter {
+                -not $ServerUri -and $ServerName -eq 'HomeServer'
+            }
+        }
+    }
+
+    Context 'When using ServerName with PassThru' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {
+                param($Name, $Default)
+                if ($Name -eq 'HomeServer') {
+                    return [PSCustomObject]@{
+                        name    = 'HomeServer'
+                        uri     = 'http://home.test:32400'
+                        token   = 'home-token'
+                        default = $false
+                    }
+                }
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatAuthenticationHeader {
+                return @{
+                    Accept         = 'application/json'
+                    'X-Plex-Token' = 'home-token'
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $null
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                return 'http://home.test:32400/library/sections/2/refresh'
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatLibrary {
+                return @{
+                    size      = 1
+                    Directory = @{
+                        key   = '2'
+                        type  = 'movie'
+                        title = 'Movies'
+                    }
+                }
+            }
+        }
+
+        It 'Passes ServerName to Get-PatLibrary when using PassThru' {
+            Update-PatLibrary -ServerName 'HomeServer' -SectionId 2 -PassThru -Confirm:$false
+            Should -Invoke -ModuleName PlexAutomationToolkit Get-PatLibrary -ParameterFilter {
+                $ServerName -eq 'HomeServer'
+            }
+        }
+    }
+
     Context 'When using Path with SectionName and default server' {
         BeforeAll {
             Mock -ModuleName PlexAutomationToolkit Get-PatStoredServer {


### PR DESCRIPTION
## Summary
- Add `-ServerName` parameter to 26+ public functions, allowing users to reference stored servers by name instead of URI
- Add new `Test-PatServer` function to validate stored server connectivity
- Fix vault prompt issue when removing servers without tokens stored in vault
- Enforce mutual exclusivity between `-ServerName` and `-ServerUri` parameters

## Test plan
- [x] All 2219 unit tests pass
- [ ] Manual test: `Get-PatLibrary -ServerName 'Home'` works correctly
- [ ] Manual test: `Test-PatServer -Name 'Home'` returns connectivity status
- [ ] Manual test: Using both `-ServerName` and `-ServerUri` throws appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)