### PR TITLE
refactor: extract helper functions from Sync-PatMedia

### DIFF
--- a/PlexAutomationToolkit/Private/Build-PatServerSplat.ps1
+++ b/PlexAutomationToolkit/Private/Build-PatServerSplat.ps1
@@ -1,0 +1,89 @@
+function Build-PatServerSplat {
+    <#
+    .SYNOPSIS
+        Builds a hashtable of server connection parameters for splatting.
+
+    .DESCRIPTION
+        Internal helper function that creates a hashtable containing the appropriate
+        server connection parameters (ServerUri/Token or ServerName) based on the
+        connection context. This eliminates repeated conditional parameter building
+        throughout the codebase.
+
+    .PARAMETER WasExplicitUri
+        Indicates whether an explicit ServerUri was provided by the user.
+        When true, ServerUri and Token parameters are used.
+        When false, ServerName is used if provided.
+
+    .PARAMETER ServerUri
+        The explicit server URI to include when WasExplicitUri is true.
+
+    .PARAMETER Token
+        The authentication token to include when WasExplicitUri is true and Token is provided.
+
+    .PARAMETER ServerName
+        The stored server name to include when WasExplicitUri is false.
+
+    .OUTPUTS
+        System.Collections.Hashtable
+        Returns a hashtable with either:
+        - ServerUri and optionally Token (when WasExplicitUri is true)
+        - ServerName (when WasExplicitUri is false and ServerName is provided)
+        - Empty hashtable (when neither condition is met)
+
+    .EXAMPLE
+        $splat = Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'abc123'
+        Get-PatLibrary @splat
+
+        Returns @{ ServerUri = 'http://plex:32400'; Token = 'abc123' }
+
+    .EXAMPLE
+        $splat = Build-PatServerSplat -WasExplicitUri $false -ServerName 'HomeServer'
+        Get-PatLibrary @splat
+
+        Returns @{ ServerName = 'HomeServer' }
+
+    .EXAMPLE
+        $context = Resolve-PatServerContext -ServerName $ServerName -ServerUri $ServerUri -Token $Token
+        $splat = Build-PatServerSplat -WasExplicitUri $context.WasExplicitUri -ServerUri $ServerUri -Token $Token -ServerName $ServerName
+        Get-PatPlaylist @splat
+
+        Builds server parameters from a resolved server context.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $WasExplicitUri,
+
+        [Parameter()]
+        [string]
+        $ServerUri,
+
+        [Parameter()]
+        [string]
+        $Token,
+
+        [Parameter()]
+        [string]
+        $ServerName
+    )
+
+    process {
+        $result = @{}
+
+        if ($WasExplicitUri) {
+            if ($ServerUri) {
+                $result['ServerUri'] = $ServerUri
+            }
+            if ($Token) {
+                $result['Token'] = $Token
+            }
+        }
+        elseif ($ServerName) {
+            $result['ServerName'] = $ServerName
+        }
+
+        $result
+    }
+}

--- a/PlexAutomationToolkit/Private/Format-PatMediaItemName.ps1
+++ b/PlexAutomationToolkit/Private/Format-PatMediaItemName.ps1
@@ -1,0 +1,52 @@
+function Format-PatMediaItemName {
+    <#
+    .SYNOPSIS
+        Formats a media item as a human-readable display name.
+
+    .DESCRIPTION
+        Internal helper function that converts a media item object to a human-readable
+        string for display in progress bars, logs, and user messages. Handles both
+        movies and TV episodes with appropriate formatting.
+
+    .PARAMETER Item
+        The media item object to format. Must have a Type property, and either:
+        - For movies: Title and Year properties
+        - For episodes: GrandparentTitle (show name), ParentIndex (season), and Index (episode)
+
+    .OUTPUTS
+        System.String
+        Returns a formatted string representing the media item.
+        - Movies: "Title (Year)" e.g., "The Matrix (1999)"
+        - Episodes: "Show - S01E05" e.g., "Breaking Bad - S01E05"
+
+    .EXAMPLE
+        $movie = [PSCustomObject]@{ Type = 'movie'; Title = 'Inception'; Year = 2010 }
+        Format-PatMediaItemName -Item $movie
+        Returns: "Inception (2010)"
+
+    .EXAMPLE
+        $episode = [PSCustomObject]@{ Type = 'episode'; GrandparentTitle = 'The Office'; ParentIndex = 3; Index = 12 }
+        Format-PatMediaItemName -Item $episode
+        Returns: "The Office - S03E12"
+
+    .EXAMPLE
+        $items | Format-PatMediaItemName
+        Formats multiple items via pipeline.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [PSCustomObject]
+        $Item
+    )
+
+    process {
+        if ($Item.Type -eq 'episode') {
+            "$($Item.GrandparentTitle) - S$($Item.ParentIndex.ToString('D2'))E$($Item.Index.ToString('D2'))"
+        }
+        else {
+            "$($Item.Title) ($($Item.Year))"
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Format-PatMediaItemName.ps1
+++ b/PlexAutomationToolkit/Private/Format-PatMediaItemName.ps1
@@ -43,10 +43,15 @@ function Format-PatMediaItemName {
 
     process {
         if ($Item.Type -eq 'episode') {
-            "$($Item.GrandparentTitle) - S$($Item.ParentIndex.ToString('D2'))E$($Item.Index.ToString('D2'))"
+            $show = if ($Item.GrandparentTitle) { $Item.GrandparentTitle } else { 'Unknown Show' }
+            $season = if ($null -ne $Item.ParentIndex) { $Item.ParentIndex.ToString('D2') } else { '00' }
+            $episode = if ($null -ne $Item.Index) { $Item.Index.ToString('D2') } else { '00' }
+            "$show - S${season}E${episode}"
         }
         else {
-            "$($Item.Title) ($($Item.Year))"
+            $title = if ($Item.Title) { $Item.Title } else { 'Unknown' }
+            $year = if ($Item.Year) { $Item.Year } else { '?' }
+            "$title ($year)"
         }
     }
 }

--- a/PlexAutomationToolkit/Private/Get-PatMediaSubtitle.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatMediaSubtitle.ps1
@@ -98,8 +98,13 @@ function Get-PatMediaSubtitle {
             return
         }
 
-        # Check if media has parts with streams
-        if (-not $mediaInformation.Media -or -not $mediaInformation.Media[0].Part) {
+        # Check if media has parts with streams (with explicit bounds checks)
+        if (-not $mediaInformation.Media -or $mediaInformation.Media.Count -eq 0) {
+            Write-Verbose "No media found for RatingKey $RatingKey"
+            return
+        }
+
+        if (-not $mediaInformation.Media[0].Part -or $mediaInformation.Media[0].Part.Count -eq 0) {
             Write-Verbose "No media parts found for RatingKey $RatingKey"
             return
         }

--- a/PlexAutomationToolkit/Private/Get-PatMediaSubtitle.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatMediaSubtitle.ps1
@@ -1,0 +1,149 @@
+function Get-PatMediaSubtitle {
+    <#
+    .SYNOPSIS
+        Downloads external subtitles for a media item.
+
+    .DESCRIPTION
+        Internal helper function that downloads all external subtitle files associated
+        with a Plex media item. Retrieves media information to find external subtitle
+        streams, then downloads each subtitle file to the same directory as the media
+        file with appropriate language code and format extension.
+
+    .PARAMETER RatingKey
+        The Plex rating key of the media item to get subtitles for.
+
+    .PARAMETER MediaDestinationPath
+        The full path where the media file is saved. Subtitle files will be saved
+        in the same directory with the same base name plus language and format.
+
+    .PARAMETER ServerUri
+        The base URI of the Plex server for downloading subtitle files.
+
+    .PARAMETER Token
+        The Plex authentication token for API requests.
+
+    .PARAMETER ServerName
+        The name of a stored server to use. Alternative to ServerUri/Token.
+
+    .PARAMETER ItemDisplayName
+        A display name for the media item, used in warning messages when
+        subtitle downloads fail.
+
+    .OUTPUTS
+        None. Writes warnings for download failures.
+
+    .EXAMPLE
+        Get-PatMediaSubtitle -RatingKey 1001 -MediaDestinationPath 'E:\Movies\Movie (2020)\Movie (2020).mkv' `
+            -ServerUri 'http://plex:32400' -Token 'abc123' -ItemDisplayName 'Movie (2020)'
+
+        Downloads all external subtitles for the media item.
+
+    .EXAMPLE
+        Get-PatMediaSubtitle -RatingKey 1001 -MediaDestinationPath 'E:\Movies\Movie (2020)\Movie (2020).mkv' `
+            -ServerName 'HomeServer' -ItemDisplayName 'Movie (2020)'
+
+        Downloads subtitles using a stored server configuration.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [int]
+        $RatingKey,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $MediaDestinationPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServerUri,
+
+        [Parameter()]
+        [string]
+        $Token,
+
+        [Parameter()]
+        [string]
+        $ServerName,
+
+        [Parameter()]
+        [string]
+        $ItemDisplayName
+    )
+
+    process {
+        # Build parameters for Get-PatMediaInfo
+        $mediaInfoParameters = @{
+            RatingKey   = $RatingKey
+            ErrorAction = 'Stop'
+        }
+
+        if ($ServerName) {
+            $mediaInfoParameters['ServerName'] = $ServerName
+        }
+        else {
+            $mediaInfoParameters['ServerUri'] = $ServerUri
+            if ($Token) {
+                $mediaInfoParameters['Token'] = $Token
+            }
+        }
+
+        try {
+            $mediaInformation = Get-PatMediaInfo @mediaInfoParameters
+        }
+        catch {
+            Write-Warning "Failed to get media info for subtitle download: $($_.Exception.Message)"
+            return
+        }
+
+        # Check if media has parts with streams
+        if (-not $mediaInformation.Media -or -not $mediaInformation.Media[0].Part) {
+            Write-Verbose "No media parts found for RatingKey $RatingKey"
+            return
+        }
+
+        # Filter for external subtitle streams (StreamType 3 = subtitle, External = true, has Key for download)
+        $subtitleStreams = $mediaInformation.Media[0].Part[0].Streams |
+            Where-Object { $_.StreamType -eq 3 -and $_.External -and $_.Key }
+
+        if (-not $subtitleStreams) {
+            Write-Verbose "No external subtitles found for RatingKey $RatingKey"
+            return
+        }
+
+        # Get base path for subtitle files (media path without extension)
+        $basePath = [System.IO.Path]::ChangeExtension($MediaDestinationPath, $null).TrimEnd('.')
+
+        foreach ($sub in $subtitleStreams) {
+            $lang = if ($sub.LanguageCode) { $sub.LanguageCode } else { 'und' }
+            $format = if ($sub.Format) { $sub.Format } else { 'srt' }
+
+            $subtitlePath = "$basePath.$lang.$format"
+
+            # Build download URL (token passed via header, not URL for security)
+            $subtitleUrl = "$ServerUri$($sub.Key)?download=1"
+
+            Write-Verbose "Downloading subtitle: $subtitlePath"
+
+            try {
+                $downloadParameters = @{
+                    Uri         = $subtitleUrl
+                    OutFile     = $subtitlePath
+                    ErrorAction = 'Stop'
+                }
+
+                if ($Token) {
+                    $downloadParameters['Token'] = $Token
+                }
+
+                Invoke-PatFileDownload @downloadParameters | Out-Null
+            }
+            catch {
+                $displayName = if ($ItemDisplayName) { $ItemDisplayName } else { "RatingKey $RatingKey" }
+                Write-Warning "Failed to download subtitle for '$displayName': $($_.Exception.Message)"
+            }
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Remove-PatSyncedFile.ps1
+++ b/PlexAutomationToolkit/Private/Remove-PatSyncedFile.ps1
@@ -1,0 +1,92 @@
+function Remove-PatSyncedFile {
+    <#
+    .SYNOPSIS
+        Removes a synced media file and cleans up empty parent directories.
+
+    .DESCRIPTION
+        Internal helper function that safely removes a file from a sync destination.
+        Validates that the file is within the destination directory before deletion
+        (security check to prevent path traversal attacks). After removing the file,
+        cleans up any empty parent directories up to the destination root.
+
+    .PARAMETER FilePath
+        The full path to the file to remove.
+
+    .PARAMETER Destination
+        The root destination directory. Files outside this directory will not be removed.
+
+    .OUTPUTS
+        None. Writes warnings for security violations or errors.
+
+    .EXAMPLE
+        Remove-PatSyncedFile -FilePath 'E:\Movies\Old Movie (2020)\Old Movie (2020).mkv' -Destination 'E:\'
+
+        Removes the file and cleans up empty parent directories.
+
+    .EXAMPLE
+        $syncPlan.RemoveOperations | ForEach-Object { Remove-PatSyncedFile -FilePath $_.Path -Destination 'E:\' }
+
+        Removes multiple files from remove operations.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Destination
+    )
+
+    process {
+        # Resolve destination to absolute path for validation
+        $resolvedDestination = [System.IO.Path]::GetFullPath($Destination)
+        # Ensure destination path ends with separator for proper prefix matching
+        if (-not $resolvedDestination.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+            $resolvedDestination += [System.IO.Path]::DirectorySeparatorChar
+        }
+
+        # Security: Validate file is within destination directory before deletion
+        $resolvedFilePath = [System.IO.Path]::GetFullPath($FilePath)
+        if (-not $resolvedFilePath.StartsWith($resolvedDestination, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Warning "Skipping removal of '$FilePath' - path is outside destination directory"
+            return
+        }
+
+        Write-Verbose "Removing: $FilePath"
+        Remove-Item -Path $resolvedFilePath -Force -ErrorAction SilentlyContinue
+
+        # Clean up empty parent directories (but stay within destination)
+        $parent = Split-Path -Path $resolvedFilePath -Parent
+        $maxIterations = 100  # Prevent infinite loop
+        $iterations = 0
+
+        while ($parent -and (Test-Path -Path $parent) -and $iterations -lt $maxIterations) {
+            $iterations++
+
+            # Stop if we've reached the destination root
+            $resolvedParent = [System.IO.Path]::GetFullPath($parent)
+            if (-not $resolvedParent.StartsWith($resolvedDestination, [System.StringComparison]::OrdinalIgnoreCase)) {
+                break
+            }
+
+            $items = Get-ChildItem -Path $parent -Force -ErrorAction SilentlyContinue
+            if (-not $items) {
+                Remove-Item -Path $parent -Force -ErrorAction SilentlyContinue
+                $newParent = Split-Path -Path $parent -Parent
+
+                # Ensure we're actually moving up the directory tree
+                if ($newParent -eq $parent) {
+                    break
+                }
+                $parent = $newParent
+            }
+            else {
+                break
+            }
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Remove-PatWatchedPlaylistItem.ps1
+++ b/PlexAutomationToolkit/Private/Remove-PatWatchedPlaylistItem.ps1
@@ -1,0 +1,185 @@
+function Remove-PatWatchedPlaylistItem {
+    <#
+    .SYNOPSIS
+        Removes watched items from a Plex playlist based on watch status differences.
+
+    .DESCRIPTION
+        Internal helper function that removes items from a playlist that have been
+        watched on another server. Takes watch status differences (from Compare-PatWatchStatus)
+        and removes matching items from the specified playlist. Shows progress during
+        removal and handles errors gracefully.
+
+    .PARAMETER WatchDiff
+        Array of watch status differences from Compare-PatWatchStatus. Each object
+        should have a TargetRatingKey property to match against playlist items.
+
+    .PARAMETER PlaylistId
+        The unique identifier of the playlist to remove items from.
+
+    .PARAMETER PlaylistName
+        The name of the playlist to remove items from. Used when PlaylistId is not specified.
+
+    .PARAMETER ServerUri
+        The base URI of the Plex server.
+
+    .PARAMETER Token
+        The Plex authentication token for API requests.
+
+    .PARAMETER ServerName
+        The name of a stored server to use. Alternative to ServerUri/Token.
+
+    .OUTPUTS
+        System.Int32
+        Returns the count of items successfully removed from the playlist.
+
+    .EXAMPLE
+        $diffs = Compare-PatWatchStatus -SourceServerName 'Travel' -TargetServerName 'Home' -WatchedOnSourceOnly
+        Remove-PatWatchedPlaylistItem -WatchDiff $diffs -PlaylistName 'Travel' -ServerName 'Home'
+
+        Removes watched items from the Travel playlist.
+
+    .EXAMPLE
+        $removed = Remove-PatWatchedPlaylistItem -WatchDiff $diffs -PlaylistId 100 -ServerUri 'http://plex:32400' -Token $token
+        Write-Host "Removed $removed items"
+
+        Removes watched items and returns the count.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [PSObject[]]
+        $WatchDiff,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $PlaylistId,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $PlaylistName,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ServerUri,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Token,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ServerName
+    )
+
+    process {
+        # Return early if no watch differences
+        if (-not $WatchDiff -or $WatchDiff.Count -eq 0) {
+            Write-Verbose "No watch differences provided"
+            return 0
+        }
+
+        # Build parameters for Get-PatPlaylist
+        $getPlaylistParameters = @{
+            IncludeItems = $true
+            ErrorAction  = 'Stop'
+        }
+
+        if ($PlaylistId) {
+            $getPlaylistParameters['PlaylistId'] = $PlaylistId
+        }
+        elseif ($PlaylistName) {
+            $getPlaylistParameters['PlaylistName'] = $PlaylistName
+        }
+        else {
+            Write-Warning "Either PlaylistId or PlaylistName must be specified"
+            return 0
+        }
+
+        if ($ServerName) {
+            $getPlaylistParameters['ServerName'] = $ServerName
+        }
+        elseif ($ServerUri) {
+            $getPlaylistParameters['ServerUri'] = $ServerUri
+            if ($Token) {
+                $getPlaylistParameters['Token'] = $Token
+            }
+        }
+
+        # Get playlist with items
+        try {
+            $playlist = Get-PatPlaylist @getPlaylistParameters
+        }
+        catch {
+            Write-Warning "Failed to get playlist: $($_.Exception.Message)"
+            return 0
+        }
+
+        if (-not $playlist.Items -or $playlist.Items.Count -eq 0) {
+            Write-Verbose "Playlist '$($playlist.Title)' has no items"
+            return 0
+        }
+
+        # Build lookup from RatingKey to PlaylistItem
+        $ratingKeyToItem = @{}
+        foreach ($item in $playlist.Items) {
+            $ratingKeyToItem[[string]$item.RatingKey] = $item
+        }
+
+        # Find watched items that are in the playlist
+        # Use TargetRatingKey which corresponds to the source (home) server's keys
+        $itemsToRemove = @()
+        foreach ($diff in $WatchDiff) {
+            $key = [string]$diff.TargetRatingKey
+            if ($ratingKeyToItem.ContainsKey($key)) {
+                $itemsToRemove += @{
+                    PlaylistItem = $ratingKeyToItem[$key]
+                    WatchDiff    = $diff
+                }
+            }
+        }
+
+        if ($itemsToRemove.Count -eq 0) {
+            Write-Verbose "No watched items found in playlist to remove"
+            return 0
+        }
+
+        Write-Verbose "Found $($itemsToRemove.Count) watched items in playlist '$($playlist.Title)'"
+
+        # Remove items from playlist
+        $removedCount = 0
+        $totalToRemove = $itemsToRemove.Count
+        $currentItem = 0
+
+        foreach ($itemToRemove in $itemsToRemove) {
+            $currentItem++
+            $playlistItem = $itemToRemove.PlaylistItem
+            $itemDisplay = Format-PatMediaItemName -Item $playlistItem
+
+            $percentComplete = [int](($currentItem / $totalToRemove) * 100)
+            Write-Progress -Activity "Removing watched items from playlist" `
+                -Status "Removing $currentItem of $totalToRemove`: $itemDisplay" `
+                -PercentComplete $percentComplete `
+                -Id 1
+
+            try {
+                Remove-PatPlaylistItem -PlaylistId $playlist.PlaylistId `
+                    -PlaylistItemId $playlistItem.PlaylistItemId `
+                    -Confirm:$false `
+                    -ErrorAction Stop
+
+                $removedCount++
+                Write-Verbose "Removed '$itemDisplay' from playlist"
+            }
+            catch {
+                Write-Warning "Failed to remove '$itemDisplay': $($_.Exception.Message)"
+            }
+        }
+
+        Write-Progress -Activity "Removing watched items from playlist" -Completed -Id 1
+        Write-Verbose "Removed $removedCount watched items from playlist"
+
+        return $removedCount
+    }
+}

--- a/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
+++ b/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
@@ -357,7 +357,7 @@ function Sync-PatMedia {
                         # Remove watched items from playlist if requested
                         if ($RemoveWatched) {
                             $removeServerSplat = Build-PatServerSplat -WasExplicitUri $script:serverContext.WasExplicitUri `
-                                -ServerUri $ServerUri -Token $effectiveToken -ServerName $ServerName
+                                -ServerUri $ServerUri -Token $Token -ServerName $ServerName
                             $removeParams = @{
                                 WatchDiff = $watchDiffs
                             } + $removeServerSplat

--- a/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
+++ b/PlexAutomationToolkit/Public/Sync-PatMedia.ps1
@@ -172,17 +172,12 @@ function Sync-PatMedia {
     process {
         try {
             # Get the sync plan - build parameters based on server context
+            $serverSplat = Build-PatServerSplat -WasExplicitUri $script:serverContext.WasExplicitUri `
+                -ServerUri $ServerUri -Token $Token -ServerName $ServerName
             $syncPlanParameters = @{
                 Destination = $Destination
                 ErrorAction = 'Stop'
-            }
-            if ($script:serverContext.WasExplicitUri) {
-                $syncPlanParameters['ServerUri'] = $ServerUri
-                if ($Token) { $syncPlanParameters['Token'] = $Token }
-            }
-            elseif ($ServerName) {
-                $syncPlanParameters['ServerName'] = $ServerName
-            }
+            } + $serverSplat
             if ($PlaylistId) {
                 $syncPlanParameters['PlaylistId'] = $PlaylistId
             }
@@ -222,13 +217,6 @@ function Sync-PatMedia {
             if (-not $SkipRemoval -and $syncPlan.RemoveOperations.Count -gt 0) {
                 Write-Verbose "Removing $($syncPlan.RemoveOperations.Count) items..."
 
-                # Resolve destination to absolute path for validation
-                $resolvedDestination = [System.IO.Path]::GetFullPath($Destination)
-                # Ensure destination path ends with separator for proper prefix matching
-                if (-not $resolvedDestination.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
-                    $resolvedDestination += [System.IO.Path]::DirectorySeparatorChar
-                }
-
                 $removeCount = 0
                 foreach ($removeOp in $syncPlan.RemoveOperations) {
                     $removeCount++
@@ -240,41 +228,7 @@ function Sync-PatMedia {
                         -CurrentOperation $removeOp.Path `
                         -Id 1
 
-                    # Security: Validate file is within destination directory before deletion
-                    $resolvedRemovePath = [System.IO.Path]::GetFullPath($removeOp.Path)
-                    if (-not $resolvedRemovePath.StartsWith($resolvedDestination, [System.StringComparison]::OrdinalIgnoreCase)) {
-                        Write-Warning "Skipping removal of '$($removeOp.Path)' - path is outside destination directory"
-                        continue
-                    }
-
-                    Write-Verbose "Removing: $($removeOp.Path)"
-                    Remove-Item -Path $resolvedRemovePath -Force -ErrorAction SilentlyContinue
-
-                    # Try to remove empty parent directories (but stay within destination)
-                    $parent = Split-Path -Path $resolvedRemovePath -Parent
-                    $maxIterations = 100  # Prevent infinite loop
-                    $iterations = 0
-                    while ($parent -and (Test-Path -Path $parent) -and $iterations -lt $maxIterations) {
-                        $iterations++
-                        # Stop if we've reached the destination root
-                        $resolvedParent = [System.IO.Path]::GetFullPath($parent)
-                        if (-not $resolvedParent.StartsWith($resolvedDestination, [System.StringComparison]::OrdinalIgnoreCase)) {
-                            break
-                        }
-                        $items = Get-ChildItem -Path $parent -Force -ErrorAction SilentlyContinue
-                        if (-not $items) {
-                            Remove-Item -Path $parent -Force -ErrorAction SilentlyContinue
-                            $newParent = Split-Path -Path $parent -Parent
-                            # Ensure we're actually moving up
-                            if ($newParent -eq $parent) {
-                                break
-                            }
-                            $parent = $newParent
-                        }
-                        else {
-                            break
-                        }
-                    }
+                    Remove-PatSyncedFile -FilePath $removeOp.Path -Destination $Destination
                 }
 
                 Write-Progress -Activity "Removing old files" -Completed -Id 1
@@ -306,12 +260,7 @@ function Sync-PatMedia {
                     $downloadCount++
                     $overallPercent = [int](($downloadedBytes / $totalBytes) * 100)
 
-                    $itemDisplay = if ($addOp.Type -eq 'episode') {
-                        "$($addOp.GrandparentTitle) - S$($addOp.ParentIndex.ToString('D2'))E$($addOp.Index.ToString('D2'))"
-                    }
-                    else {
-                        "$($addOp.Title) ($($addOp.Year))"
-                    }
+                    $itemDisplay = Format-PatMediaItemName -Item $addOp
 
                     Write-Progress -Activity "Syncing media" `
                         -Status "Downloading $downloadCount of $($syncPlan.AddOperations.Count): $itemDisplay" `
@@ -341,53 +290,19 @@ function Sync-PatMedia {
 
                         # Download subtitles if requested
                         if (-not $SkipSubtitles -and $addOp.SubtitleCount -gt 0) {
-                            # Get full media info to get subtitle streams
-                            $mediaInformationParameters = @{
-                                RatingKey   = $addOp.RatingKey
-                                ErrorAction = 'Stop'
+                            $subtitleParameters = @{
+                                RatingKey            = $addOp.RatingKey
+                                MediaDestinationPath = $addOp.DestinationPath
+                                ServerUri            = $effectiveUri
+                                ItemDisplayName      = $itemDisplay
                             }
-                            if ($script:serverContext.WasExplicitUri) {
-                                $mediaInformationParameters['ServerUri'] = $ServerUri
-                                if ($effectiveToken) { $mediaInformationParameters['Token'] = $effectiveToken }
+                            if ($effectiveToken) {
+                                $subtitleParameters['Token'] = $effectiveToken
                             }
-                            elseif ($ServerName) {
-                                $mediaInformationParameters['ServerName'] = $ServerName
+                            if ($ServerName) {
+                                $subtitleParameters['ServerName'] = $ServerName
                             }
-
-                            $mediaInformation = Get-PatMediaInfo @mediaInformationParameters
-
-                            if ($mediaInformation.Media -and $mediaInformation.Media[0].Part) {
-                                $subtitleStreams = $mediaInformation.Media[0].Part[0].Streams |
-                                    Where-Object { $_.StreamType -eq 3 -and $_.External -and $_.Key }
-
-                                foreach ($sub in $subtitleStreams) {
-                                    $lang = if ($sub.LanguageCode) { $sub.LanguageCode } else { 'und' }
-                                    $format = if ($sub.Format) { $sub.Format } else { 'srt' }
-
-                                    $basePath = [System.IO.Path]::ChangeExtension($addOp.DestinationPath, $null).TrimEnd('.')
-                                    $subPath = "$basePath.$lang.$format"
-
-                                    # Token passed via header, not URL for security
-                                    $subUrl = "$effectiveUri$($sub.Key)?download=1"
-
-                                    Write-Verbose "Downloading subtitle: $subPath"
-
-                                    try {
-                                        $subtitleDownloadParameters = @{
-                                            Uri         = $subUrl
-                                            OutFile     = $subPath
-                                            ErrorAction = 'Stop'
-                                        }
-                                        if ($effectiveToken) {
-                                            $subtitleDownloadParameters['Token'] = $effectiveToken
-                                        }
-                                        Invoke-PatFileDownload @subtitleDownloadParameters | Out-Null
-                                    }
-                                    catch {
-                                        Write-Warning "Failed to download subtitle for '$itemDisplay': $($_.Exception.Message)"
-                                    }
-                                }
-                            }
+                            Get-PatMediaSubtitle @subtitleParameters
                         }
 
                         $downloadedBytes += $addOp.MediaSize
@@ -441,91 +356,19 @@ function Sync-PatMedia {
 
                         # Remove watched items from playlist if requested
                         if ($RemoveWatched) {
-                            # Get playlist with items to map RatingKey to PlaylistItemId
-                            $getPlaylistParameters = @{
-                                IncludeItems = $true
-                                ErrorAction  = 'Stop'
-                            }
+                            $removeServerSplat = Build-PatServerSplat -WasExplicitUri $script:serverContext.WasExplicitUri `
+                                -ServerUri $ServerUri -Token $effectiveToken -ServerName $ServerName
+                            $removeParams = @{
+                                WatchDiff = $watchDiffs
+                            } + $removeServerSplat
                             if ($PlaylistId) {
-                                $getPlaylistParameters['PlaylistId'] = $PlaylistId
+                                $removeParams['PlaylistId'] = $PlaylistId
                             }
                             else {
-                                $getPlaylistParameters['PlaylistName'] = $PlaylistName
-                            }
-                            if ($script:serverContext.WasExplicitUri) {
-                                $getPlaylistParameters['ServerUri'] = $ServerUri
-                                if ($effectiveToken) { $getPlaylistParameters['Token'] = $effectiveToken }
-                            }
-                            elseif ($ServerName) {
-                                $getPlaylistParameters['ServerName'] = $ServerName
+                                $removeParams['PlaylistName'] = $PlaylistName
                             }
 
-                            $playlist = Get-PatPlaylist @getPlaylistParameters
-
-                            # Build lookup from RatingKey to PlaylistItem
-                            $ratingKeyToItem = @{}
-                            foreach ($item in $playlist.Items) {
-                                $ratingKeyToItem[[string]$item.RatingKey] = $item
-                            }
-
-                            # Find watched items that are in the playlist
-                            # Use TargetRatingKey which corresponds to the source (home) server's keys
-                            $itemsToRemove = @()
-                            foreach ($diff in $watchDiffs) {
-                                $key = [string]$diff.TargetRatingKey
-                                if ($ratingKeyToItem.ContainsKey($key)) {
-                                    $itemsToRemove += @{
-                                        PlaylistItem = $ratingKeyToItem[$key]
-                                        WatchDiff    = $diff
-                                    }
-                                }
-                            }
-
-                            if ($itemsToRemove.Count -gt 0) {
-                                $removeDescription = "$($itemsToRemove.Count) watched items from playlist '$($playlist.Title)'"
-
-                                if ($PSCmdlet.ShouldProcess($removeDescription, 'Remove')) {
-                                    $removedCount = 0
-                                    $totalToRemove = $itemsToRemove.Count
-                                    $currentItem = 0
-
-                                    foreach ($itemToRemove in $itemsToRemove) {
-                                        $currentItem++
-                                        $playlistItem = $itemToRemove.PlaylistItem
-                                        $itemDisplay = if ($playlistItem.Type -eq 'episode') {
-                                            "$($playlistItem.GrandparentTitle) - S$($playlistItem.ParentIndex.ToString('D2'))E$($playlistItem.Index.ToString('D2'))"
-                                        }
-                                        else {
-                                            "$($playlistItem.Title) ($($playlistItem.Year))"
-                                        }
-
-                                        $percentComplete = [int](($currentItem / $totalToRemove) * 100)
-                                        Write-Progress -Activity "Removing watched items from playlist" `
-                                            -Status "Removing $currentItem of $totalToRemove`: $itemDisplay" `
-                                            -PercentComplete $percentComplete `
-                                            -Id 1
-
-                                        try {
-                                            Remove-PatPlaylistItem -PlaylistId $playlist.PlaylistId `
-                                                -PlaylistItemId $playlistItem.PlaylistItemId `
-                                                -Confirm:$false `
-                                                -ErrorAction Stop
-
-                                            $removedCount++
-                                            Write-Verbose "Removed '$itemDisplay' from playlist"
-                                        }
-                                        catch {
-                                            Write-Warning "Failed to remove '$itemDisplay': $($_.Exception.Message)"
-                                        }
-                                    }
-
-                                    Write-Progress -Activity "Removing watched items from playlist" -Completed -Id 1
-                                    Write-Verbose "Removed $removedCount watched items from playlist"
-                                }
-                            }
-                            else {
-                                Write-Verbose "No watched items found in playlist to remove"
-                            }
+                            Remove-PatWatchedPlaylistItem @removeParams | Out-Null
                         }
                     }
                     else {

--- a/tests/Unit/Private/Build-PatServerSplat.tests.ps1
+++ b/tests/Unit/Private/Build-PatServerSplat.tests.ps1
@@ -1,42 +1,52 @@
 BeforeAll {
-    # Import the module from the source directory for unit testing
-    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
-    Import-Module $modulePath -Force
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
 
-    # Get the private function using module scope
-    $script:BuildPatServerSplat = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
 }
 
 Describe 'Build-PatServerSplat' {
     Context 'Explicit URI mode (WasExplicitUri = $true)' {
         It 'Returns ServerUri when provided' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+            }
 
             $result | Should -BeOfType [hashtable]
             $result.ServerUri | Should -Be 'http://plex:32400'
         }
 
         It 'Returns ServerUri and Token when both provided' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'my-token'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'my-token'
+            }
 
             $result.ServerUri | Should -Be 'http://plex:32400'
             $result.Token | Should -Be 'my-token'
         }
 
         It 'Does not include Token when not provided' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+            }
 
             $result.ContainsKey('Token') | Should -Be $false
         }
 
         It 'Does not include Token when empty string' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token ''
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token ''
+            }
 
             $result.ContainsKey('Token') | Should -Be $false
         }
 
         It 'Ignores ServerName when WasExplicitUri is true' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -ServerName 'HomeServer'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -ServerName 'HomeServer'
+            }
 
             $result.ContainsKey('ServerName') | Should -Be $false
             $result.ServerUri | Should -Be 'http://plex:32400'
@@ -45,14 +55,18 @@ Describe 'Build-PatServerSplat' {
 
     Context 'Server name mode (WasExplicitUri = $false)' {
         It 'Returns ServerName when provided' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'HomeServer'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerName 'HomeServer'
+            }
 
             $result | Should -BeOfType [hashtable]
             $result.ServerName | Should -Be 'HomeServer'
         }
 
         It 'Does not include ServerUri or Token' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'HomeServer' -ServerUri 'http://ignored:32400' -Token 'ignored'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerName 'HomeServer' -ServerUri 'http://ignored:32400' -Token 'ignored'
+            }
 
             $result.ContainsKey('ServerUri') | Should -Be $false
             $result.ContainsKey('Token') | Should -Be $false
@@ -60,14 +74,18 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Returns empty hashtable when ServerName not provided' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false
+            }
 
             $result | Should -BeOfType [hashtable]
             $result.Count | Should -Be 0
         }
 
         It 'Returns empty hashtable when ServerName is empty' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName ''
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerName ''
+            }
 
             $result.Count | Should -Be 0
         }
@@ -75,14 +93,18 @@ Describe 'Build-PatServerSplat' {
 
     Context 'Edge cases' {
         It 'Returns empty hashtable when WasExplicitUri true but no ServerUri' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true
+            }
 
             $result | Should -BeOfType [hashtable]
             $result.Count | Should -Be 0
         }
 
         It 'Handles all parameters being empty' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerUri '' -Token '' -ServerName ''
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerUri '' -Token '' -ServerName ''
+            }
 
             $result | Should -BeOfType [hashtable]
             $result.Count | Should -Be 0
@@ -91,7 +113,9 @@ Describe 'Build-PatServerSplat' {
 
     Context 'Splatting compatibility' {
         It 'Returns hashtable that can be used for splatting' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'TestServer'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerName 'TestServer'
+            }
 
             # Verify it's a proper hashtable for splatting
             $result.GetType().Name | Should -Be 'Hashtable'
@@ -99,7 +123,9 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Can be merged with other parameters' {
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'abc'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'abc'
+            }
 
             # Add additional parameters
             $result['RatingKey'] = 1001
@@ -115,8 +141,9 @@ Describe 'Build-PatServerSplat' {
     Context 'Real-world usage patterns' {
         It 'Matches pattern for Get-PatSyncPlan call' {
             # Simulating: WasExplicitUri = false, using ServerName
-            $serverName = 'HomeServer'
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName $serverName
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false -ServerName 'HomeServer'
+            }
 
             $result.ServerName | Should -Be 'HomeServer'
             $result.ContainsKey('ServerUri') | Should -Be $false
@@ -124,9 +151,11 @@ Describe 'Build-PatServerSplat' {
 
         It 'Matches pattern for explicit URI with token' {
             # Simulating: WasExplicitUri = true, explicit URI and token
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $true `
-                -ServerUri 'http://192.168.1.100:32400' `
-                -Token 'xxxxxxxxxxxxxxxxxxxx'
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $true `
+                    -ServerUri 'http://192.168.1.100:32400' `
+                    -Token 'xxxxxxxxxxxxxxxxxxxx'
+            }
 
             $result.ServerUri | Should -Be 'http://192.168.1.100:32400'
             $result.Token | Should -Be 'xxxxxxxxxxxxxxxxxxxx'
@@ -134,7 +163,9 @@ Describe 'Build-PatServerSplat' {
 
         It 'Matches pattern for default server (no explicit params)' {
             # Simulating: WasExplicitUri = false, no ServerName (uses default)
-            $result = & $script:BuildPatServerSplat -WasExplicitUri $false
+            $result = InModuleScope PlexAutomationToolkit {
+                Build-PatServerSplat -WasExplicitUri $false
+            }
 
             $result.Count | Should -Be 0
         }
@@ -142,7 +173,9 @@ Describe 'Build-PatServerSplat' {
 
     Context 'Parameter validation' {
         It 'Has mandatory WasExplicitUri parameter' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Build-PatServerSplat
+            }
             $parameter = $command.Parameters['WasExplicitUri']
 
             $parameter | Should -Not -BeNullOrEmpty
@@ -150,7 +183,9 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Has optional ServerUri parameter' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Build-PatServerSplat
+            }
             $parameter = $command.Parameters['ServerUri']
 
             $parameter | Should -Not -BeNullOrEmpty
@@ -158,7 +193,9 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Has optional Token parameter' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Build-PatServerSplat
+            }
             $parameter = $command.Parameters['Token']
 
             $parameter | Should -Not -BeNullOrEmpty
@@ -166,7 +203,9 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Has optional ServerName parameter' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Build-PatServerSplat
+            }
             $parameter = $command.Parameters['ServerName']
 
             $parameter | Should -Not -BeNullOrEmpty
@@ -174,7 +213,9 @@ Describe 'Build-PatServerSplat' {
         }
 
         It 'Returns hashtable type' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Build-PatServerSplat
+            }
             $outputType = $command.OutputType
 
             $outputType.Type.Name | Should -Contain 'Hashtable'

--- a/tests/Unit/Private/Build-PatServerSplat.tests.ps1
+++ b/tests/Unit/Private/Build-PatServerSplat.tests.ps1
@@ -1,0 +1,183 @@
+BeforeAll {
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+
+    # Get the private function using module scope
+    $script:BuildPatServerSplat = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+}
+
+Describe 'Build-PatServerSplat' {
+    Context 'Explicit URI mode (WasExplicitUri = $true)' {
+        It 'Returns ServerUri when provided' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+
+            $result | Should -BeOfType [hashtable]
+            $result.ServerUri | Should -Be 'http://plex:32400'
+        }
+
+        It 'Returns ServerUri and Token when both provided' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'my-token'
+
+            $result.ServerUri | Should -Be 'http://plex:32400'
+            $result.Token | Should -Be 'my-token'
+        }
+
+        It 'Does not include Token when not provided' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400'
+
+            $result.ContainsKey('Token') | Should -Be $false
+        }
+
+        It 'Does not include Token when empty string' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token ''
+
+            $result.ContainsKey('Token') | Should -Be $false
+        }
+
+        It 'Ignores ServerName when WasExplicitUri is true' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -ServerName 'HomeServer'
+
+            $result.ContainsKey('ServerName') | Should -Be $false
+            $result.ServerUri | Should -Be 'http://plex:32400'
+        }
+    }
+
+    Context 'Server name mode (WasExplicitUri = $false)' {
+        It 'Returns ServerName when provided' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'HomeServer'
+
+            $result | Should -BeOfType [hashtable]
+            $result.ServerName | Should -Be 'HomeServer'
+        }
+
+        It 'Does not include ServerUri or Token' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'HomeServer' -ServerUri 'http://ignored:32400' -Token 'ignored'
+
+            $result.ContainsKey('ServerUri') | Should -Be $false
+            $result.ContainsKey('Token') | Should -Be $false
+            $result.ServerName | Should -Be 'HomeServer'
+        }
+
+        It 'Returns empty hashtable when ServerName not provided' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false
+
+            $result | Should -BeOfType [hashtable]
+            $result.Count | Should -Be 0
+        }
+
+        It 'Returns empty hashtable when ServerName is empty' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName ''
+
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Returns empty hashtable when WasExplicitUri true but no ServerUri' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true
+
+            $result | Should -BeOfType [hashtable]
+            $result.Count | Should -Be 0
+        }
+
+        It 'Handles all parameters being empty' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerUri '' -Token '' -ServerName ''
+
+            $result | Should -BeOfType [hashtable]
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'Splatting compatibility' {
+        It 'Returns hashtable that can be used for splatting' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName 'TestServer'
+
+            # Verify it's a proper hashtable for splatting
+            $result.GetType().Name | Should -Be 'Hashtable'
+            $result.Keys | Should -Contain 'ServerName'
+        }
+
+        It 'Can be merged with other parameters' {
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true -ServerUri 'http://plex:32400' -Token 'abc'
+
+            # Add additional parameters
+            $result['RatingKey'] = 1001
+            $result['ErrorAction'] = 'Stop'
+
+            $result.Count | Should -Be 4
+            $result.ServerUri | Should -Be 'http://plex:32400'
+            $result.Token | Should -Be 'abc'
+            $result.RatingKey | Should -Be 1001
+        }
+    }
+
+    Context 'Real-world usage patterns' {
+        It 'Matches pattern for Get-PatSyncPlan call' {
+            # Simulating: WasExplicitUri = false, using ServerName
+            $serverName = 'HomeServer'
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false -ServerName $serverName
+
+            $result.ServerName | Should -Be 'HomeServer'
+            $result.ContainsKey('ServerUri') | Should -Be $false
+        }
+
+        It 'Matches pattern for explicit URI with token' {
+            # Simulating: WasExplicitUri = true, explicit URI and token
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $true `
+                -ServerUri 'http://192.168.1.100:32400' `
+                -Token 'xxxxxxxxxxxxxxxxxxxx'
+
+            $result.ServerUri | Should -Be 'http://192.168.1.100:32400'
+            $result.Token | Should -Be 'xxxxxxxxxxxxxxxxxxxx'
+        }
+
+        It 'Matches pattern for default server (no explicit params)' {
+            # Simulating: WasExplicitUri = false, no ServerName (uses default)
+            $result = & $script:BuildPatServerSplat -WasExplicitUri $false
+
+            $result.Count | Should -Be 0
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory WasExplicitUri parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $parameter = $command.Parameters['WasExplicitUri']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Has optional ServerUri parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $parameter = $command.Parameters['ServerUri']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Not -Contain $true
+        }
+
+        It 'Has optional Token parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $parameter = $command.Parameters['Token']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Not -Contain $true
+        }
+
+        It 'Has optional ServerName parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $parameter = $command.Parameters['ServerName']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Not -Contain $true
+        }
+
+        It 'Returns hashtable type' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Build-PatServerSplat }
+            $outputType = $command.OutputType
+
+            $outputType.Type.Name | Should -Contain 'Hashtable'
+        }
+    }
+}

--- a/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
+++ b/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
@@ -1,10 +1,10 @@
 BeforeAll {
-    # Import the module from the source directory for unit testing
-    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
-    Import-Module $modulePath -Force
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
 
-    # Get the private function using module scope
-    $script:FormatPatMediaItemName = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
 }
 
 Describe 'Format-PatMediaItemName' {
@@ -16,7 +16,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 2010
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Inception (2010)'
         }
@@ -28,7 +30,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 2010
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Scott Pilgrim vs. the World (2010)'
         }
@@ -40,7 +44,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 1977
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Star Wars: Episode IV - A New Hope (1977)'
         }
@@ -52,7 +58,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 1942
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Casablanca (1942)'
         }
@@ -67,7 +75,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 5
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Breaking Bad - S01E05'
         }
@@ -80,7 +90,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 7
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'The Office - S03E07'
         }
@@ -93,7 +105,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 1
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Friends - S10E01'
         }
@@ -106,7 +120,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 22
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'The Simpsons - S35E22'
         }
@@ -119,7 +135,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 10
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be "Grey's Anatomy - S05E10"
         }
@@ -133,7 +151,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 2020
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $item
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ item = $item } {
+                Format-PatMediaItemName -Item $item
+            }
 
             $result | Should -Be 'Some Song (2020)'
         }
@@ -145,7 +165,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 2023
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $item
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ item = $item } {
+                Format-PatMediaItemName -Item $item
+            }
 
             $result | Should -Be 'Unknown Item (2023)'
         }
@@ -159,7 +181,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 2020
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Unknown (2020)'
         }
@@ -171,7 +195,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = $null
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Test Movie (?)'
         }
@@ -184,7 +210,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 5
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Unknown Show - S01E05'
         }
@@ -197,7 +225,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 5
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Test Show - S00E05'
         }
@@ -210,7 +240,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = $null
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Test Show - S01E00'
         }
@@ -222,7 +254,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = $null
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $movie
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                Format-PatMediaItemName -Item $movie
+            }
 
             $result | Should -Be 'Unknown (?)'
         }
@@ -235,7 +269,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = $null
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $episode
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ episode = $episode } {
+                Format-PatMediaItemName -Item $episode
+            }
 
             $result | Should -Be 'Unknown Show - S00E00'
         }
@@ -249,7 +285,9 @@ Describe 'Format-PatMediaItemName' {
                 Year  = 1999
             }
 
-            $result = $movie | & $script:FormatPatMediaItemName
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ movie = $movie } {
+                $movie | Format-PatMediaItemName
+            }
 
             $result | Should -Be 'The Matrix (1999)'
         }
@@ -261,7 +299,9 @@ Describe 'Format-PatMediaItemName' {
                 [PSCustomObject]@{ Type = 'movie'; Title = 'Movie Two'; Year = 2021 }
             )
 
-            $results = $items | & $script:FormatPatMediaItemName
+            $results = InModuleScope PlexAutomationToolkit -Parameters @{ items = $items } {
+                $items | Format-PatMediaItemName
+            }
 
             $results | Should -HaveCount 3
             $results[0] | Should -Be 'Movie One (2020)'
@@ -272,7 +312,9 @@ Describe 'Format-PatMediaItemName' {
 
     Context 'Parameter validation' {
         It 'Has mandatory Item parameter' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Format-PatMediaItemName
+            }
             $parameter = $command.Parameters['Item']
 
             $parameter | Should -Not -BeNullOrEmpty
@@ -280,7 +322,9 @@ Describe 'Format-PatMediaItemName' {
         }
 
         It 'Accepts ValueFromPipeline' {
-            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+            $command = InModuleScope PlexAutomationToolkit {
+                Get-Command Format-PatMediaItemName
+            }
             $parameter = $command.Parameters['Item']
 
             $parameter.Attributes.ValueFromPipeline | Should -Contain $true
@@ -305,7 +349,9 @@ Describe 'Format-PatMediaItemName' {
                 Container        = 'mkv'
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $addOp
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ addOp = $addOp } {
+                Format-PatMediaItemName -Item $addOp
+            }
 
             $result | Should -Be 'Dune: Part Two (2024)'
         }
@@ -327,7 +373,9 @@ Describe 'Format-PatMediaItemName' {
                 Container        = 'mkv'
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $addOp
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ addOp = $addOp } {
+                Format-PatMediaItemName -Item $addOp
+            }
 
             $result | Should -Be 'Breaking Bad - S05E14'
         }
@@ -345,7 +393,9 @@ Describe 'Format-PatMediaItemName' {
                 Index            = 1
             }
 
-            $result = & $script:FormatPatMediaItemName -Item $playlistItem
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ playlistItem = $playlistItem } {
+                Format-PatMediaItemName -Item $playlistItem
+            }
 
             $result | Should -Be 'Breaking Bad - S01E01'
         }

--- a/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
+++ b/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
@@ -151,6 +151,96 @@ Describe 'Format-PatMediaItemName' {
         }
     }
 
+    Context 'Null property handling' {
+        It 'Handles null Title for movies' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = $null
+                Year  = 2020
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Unknown (2020)'
+        }
+
+        It 'Handles null Year for movies' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'Test Movie'
+                Year  = $null
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Test Movie (?)'
+        }
+
+        It 'Handles null GrandparentTitle for episodes' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = $null
+                ParentIndex      = 1
+                Index            = 5
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Unknown Show - S01E05'
+        }
+
+        It 'Handles null ParentIndex for episodes' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'Test Show'
+                ParentIndex      = $null
+                Index            = 5
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Test Show - S00E05'
+        }
+
+        It 'Handles null Index for episodes' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'Test Show'
+                ParentIndex      = 1
+                Index            = $null
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Test Show - S01E00'
+        }
+
+        It 'Handles all null properties for movie' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = $null
+                Year  = $null
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Unknown (?)'
+        }
+
+        It 'Handles all null properties for episode' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Unknown Show - S00E00'
+        }
+    }
+
     Context 'Pipeline support' {
         It 'Accepts pipeline input' {
             $movie = [PSCustomObject]@{

--- a/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
+++ b/tests/Unit/Private/Format-PatMediaItemName.tests.ps1
@@ -1,0 +1,263 @@
+BeforeAll {
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+
+    # Get the private function using module scope
+    $script:FormatPatMediaItemName = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+}
+
+Describe 'Format-PatMediaItemName' {
+    Context 'Movie formatting' {
+        It 'Formats movie with title and year' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'Inception'
+                Year  = 2010
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Inception (2010)'
+        }
+
+        It 'Handles movie with special characters in title' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'Scott Pilgrim vs. the World'
+                Year  = 2010
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Scott Pilgrim vs. the World (2010)'
+        }
+
+        It 'Handles movie with colon in title' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'Star Wars: Episode IV - A New Hope'
+                Year  = 1977
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Star Wars: Episode IV - A New Hope (1977)'
+        }
+
+        It 'Handles older movies' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'Casablanca'
+                Year  = 1942
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $movie
+
+            $result | Should -Be 'Casablanca (1942)'
+        }
+    }
+
+    Context 'Episode formatting' {
+        It 'Formats episode with show name, season, and episode' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'Breaking Bad'
+                ParentIndex      = 1
+                Index            = 5
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Breaking Bad - S01E05'
+        }
+
+        It 'Zero-pads single digit season numbers' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'The Office'
+                ParentIndex      = 3
+                Index            = 7
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'The Office - S03E07'
+        }
+
+        It 'Zero-pads single digit episode numbers' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'Friends'
+                ParentIndex      = 10
+                Index            = 1
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'Friends - S10E01'
+        }
+
+        It 'Handles double digit season and episode numbers' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = 'The Simpsons'
+                ParentIndex      = 35
+                Index            = 22
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be 'The Simpsons - S35E22'
+        }
+
+        It 'Handles show name with special characters' {
+            $episode = [PSCustomObject]@{
+                Type             = 'episode'
+                GrandparentTitle = "Grey's Anatomy"
+                ParentIndex      = 5
+                Index            = 10
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $episode
+
+            $result | Should -Be "Grey's Anatomy - S05E10"
+        }
+    }
+
+    Context 'Default type handling' {
+        It 'Uses movie format for unknown types' {
+            $item = [PSCustomObject]@{
+                Type  = 'track'
+                Title = 'Some Song'
+                Year  = 2020
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $item
+
+            $result | Should -Be 'Some Song (2020)'
+        }
+
+        It 'Uses movie format when Type is null' {
+            $item = [PSCustomObject]@{
+                Type  = $null
+                Title = 'Unknown Item'
+                Year  = 2023
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $item
+
+            $result | Should -Be 'Unknown Item (2023)'
+        }
+    }
+
+    Context 'Pipeline support' {
+        It 'Accepts pipeline input' {
+            $movie = [PSCustomObject]@{
+                Type  = 'movie'
+                Title = 'The Matrix'
+                Year  = 1999
+            }
+
+            $result = $movie | & $script:FormatPatMediaItemName
+
+            $result | Should -Be 'The Matrix (1999)'
+        }
+
+        It 'Processes multiple pipeline items' {
+            $items = @(
+                [PSCustomObject]@{ Type = 'movie'; Title = 'Movie One'; Year = 2020 }
+                [PSCustomObject]@{ Type = 'episode'; GrandparentTitle = 'Show'; ParentIndex = 1; Index = 1 }
+                [PSCustomObject]@{ Type = 'movie'; Title = 'Movie Two'; Year = 2021 }
+            )
+
+            $results = $items | & $script:FormatPatMediaItemName
+
+            $results | Should -HaveCount 3
+            $results[0] | Should -Be 'Movie One (2020)'
+            $results[1] | Should -Be 'Show - S01E01'
+            $results[2] | Should -Be 'Movie Two (2021)'
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory Item parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+            $parameter = $command.Parameters['Item']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Accepts ValueFromPipeline' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Format-PatMediaItemName }
+            $parameter = $command.Parameters['Item']
+
+            $parameter.Attributes.ValueFromPipeline | Should -Contain $true
+        }
+    }
+
+    Context 'Real-world Plex data structures' {
+        It 'Formats typical movie from AddOperations' {
+            # Simulates structure from Get-PatSyncPlan AddOperations
+            $addOp = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Dune: Part Two'
+                Type             = 'movie'
+                Year             = 2024
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                DestinationPath  = 'E:\Movies\Dune Part Two (2024)\Dune Part Two (2024).mkv'
+                MediaSize        = 15000000000
+                SubtitleCount    = 2
+                PartKey          = '/library/parts/3001/file.mkv'
+                Container        = 'mkv'
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $addOp
+
+            $result | Should -Be 'Dune: Part Two (2024)'
+        }
+
+        It 'Formats typical episode from AddOperations' {
+            # Simulates structure from Get-PatSyncPlan AddOperations
+            $addOp = [PSCustomObject]@{
+                RatingKey        = 2001
+                Title            = 'Ozymandias'
+                Type             = 'episode'
+                Year             = 2013
+                GrandparentTitle = 'Breaking Bad'
+                ParentIndex      = 5
+                Index            = 14
+                DestinationPath  = 'E:\TV\Breaking Bad\Season 05\Breaking Bad - S05E14 - Ozymandias.mkv'
+                MediaSize        = 2000000000
+                SubtitleCount    = 1
+                PartKey          = '/library/parts/4001/file.mkv'
+                Container        = 'mkv'
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $addOp
+
+            $result | Should -Be 'Breaking Bad - S05E14'
+        }
+
+        It 'Formats playlist item structure' {
+            # Simulates structure from Get-PatPlaylist Items
+            $playlistItem = [PSCustomObject]@{
+                RatingKey        = 1001
+                PlaylistItemId   = 5001
+                Title            = 'Pilot'
+                Type             = 'episode'
+                Year             = 2008
+                GrandparentTitle = 'Breaking Bad'
+                ParentIndex      = 1
+                Index            = 1
+            }
+
+            $result = & $script:FormatPatMediaItemName -Item $playlistItem
+
+            $result | Should -Be 'Breaking Bad - S01E01'
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatMediaSubtitle.tests.ps1
+++ b/tests/Unit/Private/Get-PatMediaSubtitle.tests.ps1
@@ -1,0 +1,643 @@
+BeforeAll {
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+
+    # Get the private function using module scope
+    $script:GetPatMediaSubtitle = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+
+    # Create temp directory for test files
+    $script:TestDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "PatMediaSubtitleTests_$([Guid]::NewGuid().ToString('N'))"
+    New-Item -Path $script:TestDir -ItemType Directory -Force | Out-Null
+}
+
+AfterAll {
+    # Cleanup temp directory
+    if ($script:TestDir -and (Test-Path -Path $script:TestDir)) {
+        Remove-Item -Path $script:TestDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-PatMediaSubtitle' {
+    BeforeEach {
+        # Clean up test directory before each test
+        Get-ChildItem -Path $script:TestDir -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Context 'Basic subtitle download' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Title     = 'Test Movie'
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($Uri, $OutFile, $Token)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE CONTENT")
+                return Get-Item -Path $OutFile
+            }
+        }
+
+        It 'Downloads subtitle file' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie (2020).mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            $expectedSubPath = Join-Path -Path $script:TestDir -ChildPath 'Movie (2020).eng.srt'
+            Test-Path -Path $expectedSubPath | Should -Be $true
+        }
+
+        It 'Calls Get-PatMediaInfo with correct RatingKey' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Should -Invoke -CommandName Get-PatMediaInfo -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $RatingKey -eq 1001
+            }
+        }
+
+        It 'Calls Invoke-PatFileDownload with correct URL' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $Uri -eq 'http://plex:32400/library/streams/5001?download=1'
+            }
+        }
+
+        It 'Passes token to Invoke-PatFileDownload' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'my-secret-token'
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $Token -eq 'my-secret-token'
+            }
+        }
+    }
+
+    Context 'Multiple subtitles' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        },
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5002'
+                                            LanguageCode = 'spa'
+                                            Format       = 'srt'
+                                        },
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5003'
+                                            LanguageCode = 'fra'
+                                            Format       = 'ass'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($Uri, $OutFile)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+                return Get-Item -Path $OutFile
+            }
+        }
+
+        It 'Downloads all external subtitles' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 3
+        }
+
+        It 'Creates correct file names for each language' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Test-Path (Join-Path $script:TestDir 'Movie.eng.srt') | Should -Be $true
+            Test-Path (Join-Path $script:TestDir 'Movie.spa.srt') | Should -Be $true
+            Test-Path (Join-Path $script:TestDir 'Movie.fra.ass') | Should -Be $true
+        }
+    }
+
+    Context 'Filtering streams' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        # Video stream (StreamType 1) - should be ignored
+                                        [PSCustomObject]@{
+                                            StreamType = 1
+                                            External   = $false
+                                        },
+                                        # Audio stream (StreamType 2) - should be ignored
+                                        [PSCustomObject]@{
+                                            StreamType = 2
+                                            External   = $false
+                                        },
+                                        # Embedded subtitle (External = false) - should be ignored
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $false
+                                            LanguageCode = 'eng'
+                                        },
+                                        # External subtitle without Key - should be ignored
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = $null
+                                            LanguageCode = 'deu'
+                                        },
+                                        # Valid external subtitle - should be downloaded
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'jpn'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($OutFile)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+            }
+        }
+
+        It 'Only downloads external subtitles with keys' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            # Should only call once for the valid Japanese subtitle
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 1
+        }
+
+        It 'Downloads only the valid subtitle' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Test-Path (Join-Path $script:TestDir 'Movie.jpn.srt') | Should -Be $true
+        }
+    }
+
+    Context 'Default values for missing metadata' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = $null  # Missing language
+                                            Format       = $null  # Missing format
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($OutFile)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+            }
+        }
+
+        It 'Uses "und" for missing language code' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400'
+
+            Test-Path (Join-Path $script:TestDir 'Movie.und.srt') | Should -Be $true
+        }
+
+        It 'Uses "srt" for missing format' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400'
+
+            $subPath = Join-Path $script:TestDir 'Movie.und.srt'
+            Test-Path $subPath | Should -Be $true
+        }
+    }
+
+    Context 'No subtitles available' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload { }
+        }
+
+        It 'Handles media with no streams gracefully' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @()
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            { & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Handles media with no parts gracefully' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = $null
+                        }
+                    )
+                }
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            { & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Handles media with no Media array gracefully' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = $null
+                }
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            { & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
+        }
+    }
+
+    Context 'Error handling' {
+        It 'Warns when Get-PatMediaInfo fails' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                throw "API Error: 401 Unauthorized"
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            $warnings = & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' 3>&1
+
+            $warnings | Should -Match 'Failed to get media info'
+        }
+
+        It 'Warns when subtitle download fails' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                throw "Network error"
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            $warnings = & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -ItemDisplayName 'Test Movie (2020)' 3>&1
+
+            $warnings | Should -Match 'Failed to download subtitle'
+            $warnings | Should -Match 'Test Movie \(2020\)'
+        }
+
+        It 'Continues downloading other subtitles after one fails' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        },
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5002'
+                                            LanguageCode = 'spa'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            $script:downloadCount = 0
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                $script:downloadCount++
+                if ($script:downloadCount -eq 1) {
+                    throw "First download fails"
+                }
+                # Second download succeeds
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+            $script:downloadCount = 0
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' 3>&1 | Out-Null
+
+            # Both downloads should be attempted
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 2
+        }
+    }
+
+    Context 'ServerName parameter' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($OutFile)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+            }
+        }
+
+        It 'Passes ServerName to Get-PatMediaInfo' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -ServerName 'HomeServer'
+
+            Should -Invoke -CommandName Get-PatMediaInfo -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerName -eq 'HomeServer'
+            }
+        }
+
+        It 'Prefers ServerName over ServerUri for Get-PatMediaInfo' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' -ServerName 'HomeServer' -Token 'test-token'
+
+            Should -Invoke -CommandName Get-PatMediaInfo -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerName -eq 'HomeServer' -and -not $ServerUri
+            }
+        }
+    }
+
+    Context 'Path handling' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @(
+                                [PSCustomObject]@{
+                                    Streams = @(
+                                        [PSCustomObject]@{
+                                            StreamType   = 3
+                                            External     = $true
+                                            Key          = '/library/streams/5001'
+                                            LanguageCode = 'eng'
+                                            Format       = 'srt'
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatFileDownload {
+                param($OutFile)
+                $dir = Split-Path -Path $OutFile -Parent
+                if (-not (Test-Path -Path $dir)) {
+                    New-Item -Path $dir -ItemType Directory -Force | Out-Null
+                }
+                [System.IO.File]::WriteAllText($OutFile, "SUBTITLE")
+            }
+        }
+
+        It 'Handles media path with multiple extensions correctly' {
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.2020.1080p.mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400'
+
+            # Should only remove the last extension
+            Test-Path (Join-Path $script:TestDir 'Movie.2020.1080p.eng.srt') | Should -Be $true
+        }
+
+        It 'Handles media path in subdirectory' {
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test Movie (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $mediaPath = Join-Path -Path $movieDir -ChildPath 'Test Movie (2020).mkv'
+
+            & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400'
+
+            Test-Path (Join-Path $movieDir 'Test Movie (2020).eng.srt') | Should -Be $true
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory RatingKey parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+            $parameter = $command.Parameters['RatingKey']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Has mandatory MediaDestinationPath parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+            $parameter = $command.Parameters['MediaDestinationPath']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Has mandatory ServerUri parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+            $parameter = $command.Parameters['ServerUri']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Has optional Token parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+            $parameter = $command.Parameters['Token']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Not -Contain $true
+        }
+
+        It 'Has optional ServerName parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatMediaSubtitle }
+            $parameter = $command.Parameters['ServerName']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Not -Contain $true
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatMediaSubtitle.tests.ps1
+++ b/tests/Unit/Private/Get-PatMediaSubtitle.tests.ps1
@@ -375,6 +375,42 @@ Describe 'Get-PatMediaSubtitle' {
 
             Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
         }
+
+        It 'Handles empty Media array gracefully' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @()
+                }
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            { & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Handles empty Part array gracefully' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaInfo {
+                return [PSCustomObject]@{
+                    RatingKey = 1001
+                    Media     = @(
+                        [PSCustomObject]@{
+                            Part = @()
+                        }
+                    )
+                }
+            }
+
+            $mediaPath = Join-Path -Path $script:TestDir -ChildPath 'Movie.mkv'
+
+            { & $script:GetPatMediaSubtitle -RatingKey 1001 -MediaDestinationPath $mediaPath `
+                -ServerUri 'http://plex:32400' } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-PatFileDownload -ModuleName PlexAutomationToolkit -Times 0
+        }
     }
 
     Context 'Error handling' {

--- a/tests/Unit/Private/Remove-PatSyncedFile.tests.ps1
+++ b/tests/Unit/Private/Remove-PatSyncedFile.tests.ps1
@@ -1,0 +1,379 @@
+BeforeAll {
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+
+    # Get the private function using module scope
+    $script:RemovePatSyncedFile = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatSyncedFile }
+
+    # Create temp directory for test files (cross-platform)
+    $script:TestDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "PatRemoveSyncedFileTests_$([Guid]::NewGuid().ToString('N'))"
+    New-Item -Path $script:TestDir -ItemType Directory -Force | Out-Null
+}
+
+AfterAll {
+    # Cleanup temp directory
+    if ($script:TestDir -and (Test-Path -Path $script:TestDir)) {
+        Remove-Item -Path $script:TestDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Remove-PatSyncedFile' {
+    BeforeEach {
+        # Clean up test directory before each test
+        Get-ChildItem -Path $script:TestDir -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Context 'Basic file removal' {
+        It 'Removes a file within the destination' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test Movie (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'Test Movie (2020).mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+        }
+
+        It 'Does not throw when file does not exist' {
+            $nonExistentPath = Join-Path -Path $script:TestDir -ChildPath 'Movies\NonExistent.mkv'
+
+            { & $script:RemovePatSyncedFile -FilePath $nonExistentPath -Destination $script:TestDir } |
+                Should -Not -Throw
+        }
+
+        It 'Handles files in root of destination' {
+            # Setup
+            $filePath = Join-Path -Path $script:TestDir -ChildPath 'rootfile.txt'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+        }
+    }
+
+    Context 'Empty directory cleanup' {
+        It 'Removes empty parent directory after file deletion' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Empty Movie (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'Empty Movie (2020).mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+            Test-Path -Path $movieDir | Should -Be $false
+        }
+
+        It 'Removes multiple levels of empty parent directories' {
+            # Setup - deep nested structure
+            $deepDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Genre\SubGenre\Movie (2020)'
+            New-Item -Path $deepDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $deepDir -ChildPath 'movie.mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+            Test-Path -Path $deepDir | Should -Be $false
+            Test-Path -Path (Join-Path $script:TestDir 'Movies\Genre\SubGenre') | Should -Be $false
+            Test-Path -Path (Join-Path $script:TestDir 'Movies\Genre') | Should -Be $false
+            Test-Path -Path (Join-Path $script:TestDir 'Movies') | Should -Be $false
+        }
+
+        It 'Does not remove non-empty parent directories' {
+            # Setup - two movies in same parent
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            $movie1Dir = Join-Path -Path $moviesDir -ChildPath 'Movie One (2020)'
+            $movie2Dir = Join-Path -Path $moviesDir -ChildPath 'Movie Two (2021)'
+            New-Item -Path $movie1Dir -ItemType Directory -Force | Out-Null
+            New-Item -Path $movie2Dir -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $movie1Dir -ChildPath 'Movie One (2020).mkv'
+            $file2 = Join-Path -Path $movie2Dir -ChildPath 'Movie Two (2021).mkv'
+            [System.IO.File]::WriteAllBytes($file1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($file2, [byte[]](1, 2, 3))
+
+            # Act - remove only one movie
+            & $script:RemovePatSyncedFile -FilePath $file1 -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $file1 | Should -Be $false
+            Test-Path -Path $movie1Dir | Should -Be $false
+            Test-Path -Path $file2 | Should -Be $true
+            Test-Path -Path $movie2Dir | Should -Be $true
+            Test-Path -Path $moviesDir | Should -Be $true
+        }
+
+        It 'Stops cleanup at destination root' {
+            # Setup
+            $filePath = Join-Path -Path $script:TestDir -ChildPath 'single.txt'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert - file removed but destination still exists
+            Test-Path -Path $filePath | Should -Be $false
+            Test-Path -Path $script:TestDir | Should -Be $true
+        }
+
+        It 'Handles directory with hidden files' {
+            # Setup - directory with hidden file
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Hidden Test'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $visibleFile = Join-Path -Path $movieDir -ChildPath 'movie.mkv'
+            $hiddenFile = Join-Path -Path $movieDir -ChildPath '.hidden'
+            [System.IO.File]::WriteAllBytes($visibleFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($hiddenFile, [byte[]](1, 2, 3))
+
+            # Make file hidden (Windows) or it's already hidden by name (Unix)
+            if ($IsWindows -or $PSVersionTable.PSVersion.Major -le 5) {
+                (Get-Item $hiddenFile).Attributes = 'Hidden'
+            }
+
+            # Act - remove visible file
+            & $script:RemovePatSyncedFile -FilePath $visibleFile -Destination $script:TestDir
+
+            # Assert - directory not removed because hidden file still exists
+            Test-Path -Path $visibleFile | Should -Be $false
+            Test-Path -Path $movieDir | Should -Be $true
+        }
+    }
+
+    Context 'Security: Path validation' {
+        It 'Rejects paths outside destination directory' {
+            # Setup - file in parent of destination
+            $outsidePath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'outside_test.txt'
+            [System.IO.File]::WriteAllBytes($outsidePath, [byte[]](1, 2, 3))
+
+            try {
+                # Act & Assert
+                $warnings = & $script:RemovePatSyncedFile -FilePath $outsidePath -Destination $script:TestDir 3>&1
+
+                # File should NOT be removed
+                Test-Path -Path $outsidePath | Should -Be $true
+                # Should warn
+                $warnings | Should -Match 'outside destination directory'
+            }
+            finally {
+                Remove-Item -Path $outsidePath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Rejects paths with directory traversal' {
+            # Setup
+            $legitimateDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $legitimateDir -ItemType Directory -Force | Out-Null
+
+            # Create a file outside destination
+            $outsideFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'traversal_test.txt'
+            [System.IO.File]::WriteAllBytes($outsideFile, [byte[]](1, 2, 3))
+
+            try {
+                # Attempt traversal attack
+                $traversalPath = Join-Path -Path $legitimateDir -ChildPath '..\..\traversal_test.txt'
+
+                # Act
+                $warnings = & $script:RemovePatSyncedFile -FilePath $traversalPath -Destination $script:TestDir 3>&1
+
+                # Assert - file should NOT be removed
+                Test-Path -Path $outsideFile | Should -Be $true
+                $warnings | Should -Match 'outside destination directory'
+            }
+            finally {
+                Remove-Item -Path $outsideFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Allows paths that resolve within destination despite relative components' {
+            # Setup - path with .. that still resolves inside destination
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'movie.mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Path with relative component that still resolves to same file
+            $relativePath = Join-Path -Path $script:TestDir -ChildPath 'Movies\Other\..\Test\movie.mkv'
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $relativePath -Destination $script:TestDir
+
+            # Assert - file should be removed (it's legitimately inside destination)
+            Test-Path -Path $filePath | Should -Be $false
+        }
+
+        It 'Handles case-insensitive path comparison on Windows' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'movie.mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Use different case for destination
+            $upperDestination = $script:TestDir.ToUpper()
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $upperDestination
+
+            # Assert - should work regardless of case
+            Test-Path -Path $filePath | Should -Be $false
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Handles destination with trailing separator' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'movie.mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Destination with trailing separator
+            $destinationWithSep = $script:TestDir + [System.IO.Path]::DirectorySeparatorChar
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $destinationWithSep
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+        }
+
+        It 'Handles destination without trailing separator' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath 'movie.mkv'
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Destination without trailing separator
+            $destinationNoSep = $script:TestDir.TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $destinationNoSep
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+        }
+
+        It 'Handles files with special characters in name' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+            $filePath = Join-Path -Path $movieDir -ChildPath "Movie with 'quotes' & ampersand.mkv"
+            [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+            # Assert
+            Test-Path -Path $filePath | Should -Be $false
+        }
+
+        It 'Handles very long paths' {
+            # Setup - create nested structure approaching path limits
+            $nestedPath = $script:TestDir
+            for ($i = 0; $i -lt 10; $i++) {
+                $nestedPath = Join-Path -Path $nestedPath -ChildPath "Nested$i"
+            }
+
+            try {
+                New-Item -Path $nestedPath -ItemType Directory -Force | Out-Null
+                $filePath = Join-Path -Path $nestedPath -ChildPath 'deep.txt'
+                [System.IO.File]::WriteAllBytes($filePath, [byte[]](1, 2, 3))
+
+                # Act
+                & $script:RemovePatSyncedFile -FilePath $filePath -Destination $script:TestDir
+
+                # Assert
+                Test-Path -Path $filePath | Should -Be $false
+            }
+            catch {
+                # Some systems may not support very long paths - skip gracefully
+                Set-ItResult -Skipped -Because "System does not support long paths"
+            }
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory FilePath parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatSyncedFile }
+            $parameter = $command.Parameters['FilePath']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Has mandatory Destination parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatSyncedFile }
+            $parameter = $command.Parameters['Destination']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Validates FilePath is not null or empty' {
+            { & $script:RemovePatSyncedFile -FilePath '' -Destination $script:TestDir } |
+                Should -Throw
+        }
+
+        It 'Validates Destination is not null or empty' {
+            { & $script:RemovePatSyncedFile -FilePath 'C:\test.txt' -Destination '' } |
+                Should -Throw
+        }
+    }
+
+    Context 'Real-world sync scenarios' {
+        It 'Handles typical movie removal from sync destination' {
+            # Setup - simulate Plex folder structure
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\The Matrix (1999)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $movieFile = Join-Path -Path $movieDir -ChildPath 'The Matrix (1999).mkv'
+            $subtitleFile = Join-Path -Path $movieDir -ChildPath 'The Matrix (1999).eng.srt'
+            [System.IO.File]::WriteAllBytes($movieFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($subtitleFile, [byte[]](1, 2, 3))
+
+            # Act - remove movie file (subtitle remains)
+            & $script:RemovePatSyncedFile -FilePath $movieFile -Destination $script:TestDir
+
+            # Assert - movie removed, subtitle and directory remain
+            Test-Path -Path $movieFile | Should -Be $false
+            Test-Path -Path $subtitleFile | Should -Be $true
+            Test-Path -Path $movieDir | Should -Be $true
+        }
+
+        It 'Handles typical TV episode removal with full cleanup' {
+            # Setup - simulate Plex TV folder structure
+            $showDir = Join-Path -Path $script:TestDir -ChildPath 'TV Shows\Breaking Bad'
+            $seasonDir = Join-Path -Path $showDir -ChildPath 'Season 01'
+            New-Item -Path $seasonDir -ItemType Directory -Force | Out-Null
+
+            $episodeFile = Join-Path -Path $seasonDir -ChildPath 'Breaking Bad - S01E01 - Pilot.mkv'
+            [System.IO.File]::WriteAllBytes($episodeFile, [byte[]](1, 2, 3))
+
+            # Act
+            & $script:RemovePatSyncedFile -FilePath $episodeFile -Destination $script:TestDir
+
+            # Assert - entire structure cleaned up
+            Test-Path -Path $episodeFile | Should -Be $false
+            Test-Path -Path $seasonDir | Should -Be $false
+            Test-Path -Path $showDir | Should -Be $false
+            Test-Path -Path (Join-Path $script:TestDir 'TV Shows') | Should -Be $false
+        }
+    }
+}

--- a/tests/Unit/Private/Remove-PatWatchedPlaylistItem.tests.ps1
+++ b/tests/Unit/Private/Remove-PatWatchedPlaylistItem.tests.ps1
@@ -1,0 +1,488 @@
+BeforeAll {
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+
+    # Get the private function using module scope
+    $script:RemovePatWatchedPlaylistItem = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatWatchedPlaylistItem }
+}
+
+Describe 'Remove-PatWatchedPlaylistItem' {
+    Context 'Basic removal' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Watched Movie'
+                            Type           = 'movie'
+                            Year           = 2020
+                        },
+                        [PSCustomObject]@{
+                            RatingKey      = 1002
+                            PlaylistItemId = 5002
+                            Title          = 'Unwatched Movie'
+                            Type           = 'movie'
+                            Year           = 2021
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Removes watched items from playlist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{
+                    Title           = 'Watched Movie'
+                    TargetRatingKey = 1001
+                }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 1
+        }
+
+        It 'Returns count of removed items' {
+            $watchDiffs = @(
+                [PSCustomObject]@{
+                    Title           = 'Watched Movie'
+                    TargetRatingKey = 1001
+                }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            $result | Should -Be 1
+        }
+
+        It 'Passes correct PlaylistId and PlaylistItemId to Remove-PatPlaylistItem' {
+            $watchDiffs = @(
+                [PSCustomObject]@{
+                    Title           = 'Watched Movie'
+                    TargetRatingKey = 1001
+                }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $PlaylistId -eq 100 -and $PlaylistItemId -eq 5001
+            }
+        }
+    }
+
+    Context 'Multiple items removal' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Movie One'
+                            Type           = 'movie'
+                            Year           = 2020
+                        },
+                        [PSCustomObject]@{
+                            RatingKey      = 1002
+                            PlaylistItemId = 5002
+                            Title          = 'Movie Two'
+                            Type           = 'movie'
+                            Year           = 2021
+                        },
+                        [PSCustomObject]@{
+                            RatingKey      = 1003
+                            PlaylistItemId = 5003
+                            Title          = 'Movie Three'
+                            Type           = 'movie'
+                            Year           = 2022
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Removes multiple watched items' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie One'; TargetRatingKey = 1001 },
+                [PSCustomObject]@{ Title = 'Movie Three'; TargetRatingKey = 1003 }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 2
+            $result | Should -Be 2
+        }
+
+        It 'Only removes items that exist in playlist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie One'; TargetRatingKey = 1001 },
+                [PSCustomObject]@{ Title = 'Not In Playlist'; TargetRatingKey = 9999 }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 1
+            $result | Should -Be 1
+        }
+    }
+
+    Context 'No matching items' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Movie'
+                            Type           = 'movie'
+                            Year           = 2020
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Returns 0 when no items match' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Different Movie'; TargetRatingKey = 9999 }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            $result | Should -Be 0
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Returns 0 when watch diffs is empty' {
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff @() -PlaylistName 'Travel'
+
+            $result | Should -Be 0
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -Times 0
+        }
+    }
+
+    Context 'Empty playlist' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Empty Playlist'
+                    PlaylistId = 100
+                    Items      = @()
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Returns 0 for empty playlist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Empty Playlist'
+
+            $result | Should -Be 0
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 0
+        }
+    }
+
+    Context 'Error handling' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Movie One'
+                            Type           = 'movie'
+                            Year           = 2020
+                        },
+                        [PSCustomObject]@{
+                            RatingKey      = 1002
+                            PlaylistItemId = 5002
+                            Title          = 'Movie Two'
+                            Type           = 'movie'
+                            Year           = 2021
+                        }
+                    )
+                }
+            }
+        }
+
+        It 'Continues after removal failure' {
+            $script:callCount = 0
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem {
+                $script:callCount++
+                if ($script:callCount -eq 1) {
+                    throw "API Error"
+                }
+            }
+
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie One'; TargetRatingKey = 1001 },
+                [PSCustomObject]@{ Title = 'Movie Two'; TargetRatingKey = 1002 }
+            )
+
+            $script:callCount = 0
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' 3>&1
+
+            # Both removals should be attempted
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -Times 2
+        }
+
+        It 'Returns count of successful removals' {
+            $script:callCount = 0
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem {
+                $script:callCount++
+                if ($script:callCount -eq 1) {
+                    throw "API Error"
+                }
+            }
+
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie One'; TargetRatingKey = 1001 },
+                [PSCustomObject]@{ Title = 'Movie Two'; TargetRatingKey = 1002 }
+            )
+
+            $script:callCount = 0
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' 3>&1 |
+                Where-Object { $_ -is [int] }
+
+            # Only second removal succeeded
+            $result | Should -Be 1
+        }
+
+        It 'Warns when Get-PatPlaylist fails' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                throw "404 Not Found"
+            }
+
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            $output = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'NotFound' 3>&1
+            $warnings = $output | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+            $warnings | Should -Match 'Failed to get playlist'
+        }
+
+        It 'Returns 0 when Get-PatPlaylist fails' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                throw "404 Not Found"
+            }
+
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'NotFound' 3>&1 |
+                Where-Object { $_ -is [int] }
+
+            $result | Should -Be 0
+        }
+    }
+
+    Context 'Playlist identification' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Movie'
+                            Type           = 'movie'
+                            Year           = 2020
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Accepts PlaylistId parameter' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistId 100
+
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $PlaylistId -eq 100
+            }
+        }
+
+        It 'Accepts PlaylistName parameter' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $PlaylistName -eq 'Travel'
+            }
+        }
+
+        It 'Warns when neither PlaylistId nor PlaylistName provided' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            $output = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs 3>&1
+            $warnings = $output | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+            $warnings | Should -Match 'PlaylistId or PlaylistName must be specified'
+        }
+    }
+
+    Context 'Server connection parameters' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey      = 1001
+                            PlaylistItemId = 5001
+                            Title          = 'Movie'
+                            Type           = 'movie'
+                            Year           = 2020
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Passes ServerName to Get-PatPlaylist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' -ServerName 'HomeServer'
+
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerName -eq 'HomeServer'
+            }
+        }
+
+        It 'Passes ServerUri and Token to Get-PatPlaylist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerUri -eq 'http://plex:32400' -and $Token -eq 'test-token'
+            }
+        }
+
+        It 'Prefers ServerName over ServerUri' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' `
+                -ServerName 'HomeServer' -ServerUri 'http://plex:32400'
+
+            Should -Invoke -CommandName Get-PatPlaylist -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerName -eq 'HomeServer' -and -not $ServerUri
+            }
+        }
+    }
+
+    Context 'Episode handling' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatPlaylist {
+                return [PSCustomObject]@{
+                    Title      = 'Travel'
+                    PlaylistId = 100
+                    Items      = @(
+                        [PSCustomObject]@{
+                            RatingKey        = 2001
+                            PlaylistItemId   = 6001
+                            Title            = 'Pilot'
+                            Type             = 'episode'
+                            GrandparentTitle = 'Breaking Bad'
+                            ParentIndex      = 1
+                            Index            = 1
+                        }
+                    )
+                }
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Remove-PatPlaylistItem { }
+        }
+
+        It 'Removes episode items from playlist' {
+            $watchDiffs = @(
+                [PSCustomObject]@{
+                    Title           = 'Pilot'
+                    Type            = 'episode'
+                    TargetRatingKey = 2001
+                }
+            )
+
+            $result = & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel'
+
+            $result | Should -Be 1
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $PlaylistItemId -eq 6001
+            }
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory WatchDiff parameter' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatWatchedPlaylistItem }
+            $parameter = $command.Parameters['WatchDiff']
+
+            $parameter | Should -Not -BeNullOrEmpty
+            $parameter.Attributes.Mandatory | Should -Contain $true
+        }
+
+        It 'Allows empty collection for WatchDiff' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatWatchedPlaylistItem }
+            $parameter = $command.Parameters['WatchDiff']
+
+            $allowEmpty = $parameter.Attributes | Where-Object { $_.TypeId.Name -eq 'AllowEmptyCollectionAttribute' }
+            $allowEmpty | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Returns int type' {
+            $command = & (Get-Module PlexAutomationToolkit) { Get-Command Remove-PatWatchedPlaylistItem }
+            $outputType = $command.OutputType
+
+            $outputType.Type.Name | Should -Contain 'Int32'
+        }
+    }
+}

--- a/tests/Unit/Private/Remove-PatWatchedPlaylistItem.tests.ps1
+++ b/tests/Unit/Private/Remove-PatWatchedPlaylistItem.tests.ps1
@@ -418,6 +418,31 @@ Describe 'Remove-PatWatchedPlaylistItem' {
                 $ServerName -eq 'HomeServer' -and -not $ServerUri
             }
         }
+
+        It 'Passes ServerName to Remove-PatPlaylistItem' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' -ServerName 'HomeServer'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerName -eq 'HomeServer'
+            }
+        }
+
+        It 'Passes ServerUri and Token to Remove-PatPlaylistItem' {
+            $watchDiffs = @(
+                [PSCustomObject]@{ Title = 'Movie'; TargetRatingKey = 1001 }
+            )
+
+            & $script:RemovePatWatchedPlaylistItem -WatchDiff $watchDiffs -PlaylistName 'Travel' `
+                -ServerUri 'http://plex:32400' -Token 'test-token'
+
+            Should -Invoke -CommandName Remove-PatPlaylistItem -ModuleName PlexAutomationToolkit -ParameterFilter {
+                $ServerUri -eq 'http://plex:32400' -and $Token -eq 'test-token'
+            }
+        }
     }
 
     Context 'Episode handling' {


### PR DESCRIPTION
## Summary

- Extracts 5 private helper functions from `Sync-PatMedia` to improve testability and reduce complexity
- Reduces `Sync-PatMedia.ps1` from 546 lines to 389 lines (28.8% reduction)
- Adds 140 new unit tests for the extracted functions

### Extracted Functions

| Function | Purpose |
|----------|---------|
| `Format-PatMediaItemName` | Formats media items for display (movies vs episodes) |
| `Remove-PatSyncedFile` | Safe file removal with path validation and empty directory cleanup |
| `Get-PatMediaSubtitle` | Downloads external subtitles for media items |
| `Build-PatServerSplat` | Builds server connection parameter hashtables for splatting |
| `Remove-PatWatchedPlaylistItem` | Removes watched items from playlists based on watch status |

### Code Review Fixes

Addressed issues found during code review:
- Added null-safe property access in `Format-PatMediaItemName`
- Added explicit array bounds checks in `Get-PatMediaSubtitle`
- Fixed O(n²) performance in `Remove-PatWatchedPlaylistItem` (changed `+=` to `List.Add()`)
- Added missing server parameters to `Remove-PatPlaylistItem` call
- Fixed token scope issue in `Sync-PatMedia` vacation workflow

## Test plan

- [x] All 2398 existing tests pass
- [x] 140 new tests added for extracted functions
- [x] Null handling edge cases covered
- [x] Security validation (path traversal protection) tested
- [x] Pipeline input support verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)