### PR TITLE
refactor: extract helper functions from Get-PatSyncPlan

### DIFF
--- a/PlexAutomationToolkit/Private/Get-PatDestinationFreeSpace.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatDestinationFreeSpace.ps1
@@ -1,0 +1,63 @@
+function Get-PatDestinationFreeSpace {
+    <#
+    .SYNOPSIS
+        Gets the available free space at a destination path.
+
+    .DESCRIPTION
+        Internal helper function that determines the available free space at a destination
+        path. Handles both standard drive letters (e.g., C:\) and UNC paths. Returns 0
+        if the free space cannot be determined.
+
+    .PARAMETER Path
+        The destination path to check for free space. Can be a drive letter path or UNC path.
+
+    .OUTPUTS
+        System.Int64
+        Returns the available free space in bytes, or 0 if it cannot be determined.
+
+    .EXAMPLE
+        Get-PatDestinationFreeSpace -Path 'E:\'
+
+        Returns the free space on drive E:.
+
+    .EXAMPLE
+        Get-PatDestinationFreeSpace -Path '\\server\share\folder'
+
+        Returns the free space on the UNC path.
+    #>
+    [CmdletBinding()]
+    [OutputType([long])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
+
+    process {
+        $destinationFree = 0
+
+        try {
+            # Handle drive letters (e.g., C:\, E:\path\to\folder)
+            if ($Path -match '^([A-Z]):') {
+                $driveLetter = $Matches[1]
+                $drive = Get-PSDrive -Name $driveLetter -ErrorAction Stop
+                $destinationFree = $drive.Free
+            }
+            else {
+                # For UNC paths or when drive info isn't available, try filesystem info
+                $driveInformation = [System.IO.DriveInfo]::GetDrives() |
+                    Where-Object { $Path.StartsWith($_.Name, [StringComparison]::OrdinalIgnoreCase) } |
+                    Select-Object -First 1
+                if ($driveInformation) {
+                    $destinationFree = $driveInformation.AvailableFreeSpace
+                }
+            }
+        }
+        catch {
+            Write-Warning "Could not determine free space at destination: $($_.Exception.Message)"
+        }
+
+        return $destinationFree
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-PatDestinationFreeSpace.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatDestinationFreeSpace.ps1
@@ -35,11 +35,11 @@ function Get-PatDestinationFreeSpace {
     )
 
     process {
-        $destinationFree = 0
+        [long]$destinationFree = 0
 
         try {
-            # Handle drive letters (e.g., C:\, E:\path\to\folder)
-            if ($Path -match '^([A-Z]):') {
+            # Handle drive letters (e.g., C:\, E:\path\to\folder) - case-insensitive match
+            if ($Path -match '^([A-Za-z]):') {
                 $driveLetter = $Matches[1]
                 $drive = Get-PSDrive -Name $driveLetter -ErrorAction Stop
                 $destinationFree = $drive.Free

--- a/PlexAutomationToolkit/Private/Get-PatSyncAddOperation.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatSyncAddOperation.ps1
@@ -1,0 +1,96 @@
+function Get-PatSyncAddOperation {
+    <#
+    .SYNOPSIS
+        Determines if a media item needs to be downloaded and returns an add operation.
+
+    .DESCRIPTION
+        Internal helper function that analyzes a media item to determine if it needs
+        to be downloaded. Checks if the file exists at the destination with the correct
+        size, and if not, returns an add operation with all necessary download details.
+
+    .PARAMETER MediaInfo
+        The media information object from Get-PatMediaInfo.
+
+    .PARAMETER BasePath
+        The base destination path where media files will be synced.
+
+    .OUTPUTS
+        PSCustomObject or $null
+        Returns an add operation object if download is needed, or $null if the file
+        already exists with the correct size.
+
+    .EXAMPLE
+        $mediaInfo = Get-PatMediaInfo -RatingKey 1234
+        $addOp = Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath 'E:\'
+
+        Returns an add operation if the media needs to be downloaded.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSObject]
+        $MediaInfo,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $BasePath
+    )
+
+    process {
+        # Validate media info has required data
+        if (-not $MediaInfo.Media -or $MediaInfo.Media.Count -eq 0) {
+            Write-Verbose "No media files found for '$($MediaInfo.Title)'"
+            return $null
+        }
+
+        # Use the first media version (default behavior)
+        $media = $MediaInfo.Media[0]
+        if (-not $media.Part -or $media.Part.Count -eq 0) {
+            Write-Verbose "No media parts found for '$($MediaInfo.Title)'"
+            return $null
+        }
+
+        $part = $media.Part[0]
+
+        # Determine destination path
+        $extension = if ($part.Container) { $part.Container } else { 'mkv' }
+        $destPath = Get-PatMediaPath -MediaInfo $MediaInfo -BasePath $BasePath -Extension $extension
+
+        # Check if file already exists with correct size
+        if (Test-Path -Path $destPath) {
+            $existingFile = Get-Item -Path $destPath
+            if ($existingFile.Length -eq $part.Size) {
+                Write-Verbose "File already exists with correct size: $destPath"
+                return $null
+            }
+            else {
+                Write-Verbose "File exists but size mismatch: $destPath (expected $($part.Size), got $($existingFile.Length))"
+            }
+        }
+
+        # Count external subtitles
+        $subtitleCount = 0
+        if ($part.Streams) {
+            $subtitleCount = @($part.Streams | Where-Object { $_.StreamType -eq 3 -and $_.External }).Count
+        }
+
+        # Return add operation
+        return [PSCustomObject]@{
+            PSTypeName       = 'PlexAutomationToolkit.SyncAddOperation'
+            RatingKey        = $MediaInfo.RatingKey
+            Title            = $MediaInfo.Title
+            Type             = $MediaInfo.Type
+            Year             = $MediaInfo.Year
+            GrandparentTitle = $MediaInfo.GrandparentTitle
+            ParentIndex      = $MediaInfo.ParentIndex
+            Index            = $MediaInfo.Index
+            DestinationPath  = $destPath
+            MediaSize        = $part.Size
+            SubtitleCount    = $subtitleCount
+            PartKey          = $part.Key
+            Container        = $part.Container
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-PatSyncRemoveOperation.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatSyncRemoveOperation.ps1
@@ -1,0 +1,80 @@
+function Get-PatSyncRemoveOperation {
+    <#
+    .SYNOPSIS
+        Finds media files in a folder that should be removed during sync.
+
+    .DESCRIPTION
+        Internal helper function that scans a folder for media files and identifies
+        those that are not in the expected paths list. Returns remove operation objects
+        for files that should be deleted.
+
+    .PARAMETER FolderPath
+        The folder path to scan for media files.
+
+    .PARAMETER ExpectedPaths
+        A hashtable of expected file paths. Files not in this hashtable will be
+        marked for removal.
+
+    .PARAMETER MediaType
+        The type of media being scanned ('movie' or 'episode').
+
+    .OUTPUTS
+        PlexAutomationToolkit.SyncRemoveOperation[]
+        Returns an array of remove operation objects.
+
+    .EXAMPLE
+        $expected = @{ 'E:\Movies\Movie.mkv' = $true }
+        Get-PatSyncRemoveOperation -FolderPath 'E:\Movies' -ExpectedPaths $expected -MediaType 'movie'
+
+        Returns remove operations for any movie files not in the expected paths.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $FolderPath,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $ExpectedPaths,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('movie', 'episode')]
+        [string]
+        $MediaType
+    )
+
+    process {
+        $removeOperations = [System.Collections.Generic.List[PSCustomObject]]::new()
+        $totalBytes = 0
+
+        if (-not (Test-Path -Path $FolderPath)) {
+            return @{
+                Operations = @()
+                TotalBytes = 0
+            }
+        }
+
+        $mediaFiles = Get-ChildItem -Path $FolderPath -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -match '\.(mkv|mp4|avi|m4v|mov|ts|wmv)$' }
+
+        foreach ($file in $mediaFiles) {
+            if (-not $ExpectedPaths.ContainsKey($file.FullName)) {
+                $removeOperations.Add([PSCustomObject]@{
+                    PSTypeName = 'PlexAutomationToolkit.SyncRemoveOperation'
+                    Path       = $file.FullName
+                    Size       = $file.Length
+                    Type       = $MediaType
+                })
+                $totalBytes += $file.Length
+            }
+        }
+
+        return @{
+            Operations = $removeOperations.ToArray()
+            TotalBytes = $totalBytes
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-PatSyncRemoveOperation.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatSyncRemoveOperation.ps1
@@ -19,8 +19,8 @@ function Get-PatSyncRemoveOperation {
         The type of media being scanned ('movie' or 'episode').
 
     .OUTPUTS
-        PlexAutomationToolkit.SyncRemoveOperation[]
-        Returns an array of remove operation objects.
+        System.Collections.Hashtable
+        Returns a hashtable with Operations (array of SyncRemoveOperation objects) and TotalBytes (total size of files to remove).
 
     .EXAMPLE
         $expected = @{ 'E:\Movies\Movie.mkv' = $true }
@@ -29,7 +29,7 @@ function Get-PatSyncRemoveOperation {
         Returns remove operations for any movie files not in the expected paths.
     #>
     [CmdletBinding()]
-    [OutputType([PSCustomObject[]])]
+    [OutputType([hashtable])]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/tests/Unit/Private/Get-PatDestinationFreeSpace.tests.ps1
+++ b/tests/Unit/Private/Get-PatDestinationFreeSpace.tests.ps1
@@ -1,0 +1,323 @@
+BeforeAll {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+}
+
+Describe 'Get-PatDestinationFreeSpace' {
+    Context 'Drive letter paths' {
+        It 'Returns free space for a valid drive letter path' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'C'
+                        Free = 500GB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'C:\'
+
+                $result | Should -Be 500GB
+            }
+        }
+
+        It 'Handles drive letter with nested path' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'E'
+                        Free = 1TB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'E:\Movies\Action'
+
+                $result | Should -Be 1TB
+            }
+        }
+
+        It 'Extracts correct drive letter from path' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    param($Name)
+                    if ($Name -eq 'D') {
+                        return [PSCustomObject]@{
+                            Name = 'D'
+                            Free = 250GB
+                        }
+                    }
+                    throw "Drive not found"
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'D:\Media\TV Shows\Breaking Bad'
+
+                Should -Invoke -CommandName Get-PSDrive -ParameterFilter { $Name -eq 'D' }
+                $result | Should -Be 250GB
+            }
+        }
+
+        It 'Lowercase drive letters fall through to DriveInfo lookup' {
+            InModuleScope PlexAutomationToolkit {
+                # The regex uses [A-Z] which doesn't match lowercase
+                # So lowercase paths fall through to DriveInfo.GetDrives() lookup
+                $result = Get-PatDestinationFreeSpace -Path 'c:\test'
+
+                # On Windows, DriveInfo.GetDrives() will find C: drive regardless of case
+                # Result should be the actual free space or 0 on non-Windows
+                $result | Should -BeGreaterOrEqual 0
+            }
+        }
+
+        It 'Returns free space as long type' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'C'
+                        Free = 123456789012
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'C:\'
+
+                $result | Should -BeOfType [long]
+                $result | Should -Be 123456789012
+            }
+        }
+    }
+
+    Context 'UNC path handling' {
+        It 'Attempts to get free space for UNC paths' {
+            InModuleScope PlexAutomationToolkit {
+                # For UNC paths, the function uses DriveInfo.GetDrives()
+                # Since we can't easily mock static .NET methods, we verify behavior
+                $result = Get-PatDestinationFreeSpace -Path '\\server\share\folder'
+
+                # Result will be 0 unless the path matches a mounted drive
+                # The return type is int when 0 is returned directly, or long for actual free space
+                $result | Should -Be 0
+            }
+        }
+
+        It 'Returns 0 when UNC path does not match any drive' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-PatDestinationFreeSpace -Path '\\nonexistent\share'
+
+                $result | Should -Be 0
+            }
+        }
+
+        It 'Handles UNC path with nested folders' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-PatDestinationFreeSpace -Path '\\NAS\Media\Movies\Action\Movie.mkv'
+
+                # Result is 0 for non-existent UNC paths
+                $result | Should -Be 0
+            }
+        }
+    }
+
+    Context 'Error handling' {
+        It 'Returns 0 when Get-PSDrive fails' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    throw "Drive not accessible"
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'X:\'
+
+                $result | Should -Be 0
+            }
+        }
+
+        It 'Writes warning when drive info cannot be determined' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    throw "Access denied"
+                }
+
+                Mock Write-Warning { }
+
+                Get-PatDestinationFreeSpace -Path 'Z:\test'
+
+                Should -Invoke -CommandName Write-Warning -Times 1
+            }
+        }
+
+        It 'Warning message contains exception details' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    throw "Specific error message"
+                }
+
+                $warningMessage = $null
+                Mock Write-Warning {
+                    param($Message)
+                    $script:capturedWarning = $Message
+                }
+
+                Get-PatDestinationFreeSpace -Path 'Z:\test'
+
+                $script:capturedWarning | Should -Match 'Could not determine free space'
+                $script:capturedWarning | Should -Match 'Specific error message'
+            }
+        }
+
+        It 'Returns 0 and does not throw on any error' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    throw [System.UnauthorizedAccessException]::new("Access denied")
+                }
+
+                {
+                    $result = Get-PatDestinationFreeSpace -Path 'C:\'
+                    $result | Should -Be 0
+                } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory Path parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatDestinationFreeSpace
+                $parameter = $command.Parameters['Path']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'Path parameter validates not null or empty' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatDestinationFreeSpace
+                $parameter = $command.Parameters['Path']
+
+                $validateAttribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] }
+                $validateAttribute | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Throws on empty path' {
+            InModuleScope PlexAutomationToolkit {
+                { Get-PatDestinationFreeSpace -Path '' } | Should -Throw
+            }
+        }
+
+        It 'Throws on null path' {
+            InModuleScope PlexAutomationToolkit {
+                { Get-PatDestinationFreeSpace -Path $null } | Should -Throw
+            }
+        }
+
+        It 'Returns long type as specified in OutputType' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatDestinationFreeSpace
+                $outputType = $command.OutputType
+
+                $outputType.Type | Should -Contain ([long])
+            }
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Handles drive with zero free space' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'C'
+                        Free = 0
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'C:\'
+
+                $result | Should -Be 0
+            }
+        }
+
+        It 'Handles very large free space values' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'C'
+                        Free = 10TB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'C:\'
+
+                $result | Should -Be 10TB
+            }
+        }
+
+        It 'Handles path with spaces' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'E'
+                        Free = 500GB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'E:\My Videos\TV Shows'
+
+                $result | Should -Be 500GB
+            }
+        }
+
+        It 'Handles path with special characters' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'D'
+                        Free = 200GB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path "D:\Movies\Movie's Collection (2020)"
+
+                $result | Should -Be 200GB
+            }
+        }
+
+        It 'Handles drive letter only path' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Get-PSDrive {
+                    return [PSCustomObject]@{
+                        Name = 'C'
+                        Free = 100GB
+                    }
+                }
+
+                $result = Get-PatDestinationFreeSpace -Path 'C:'
+
+                # 'C:' matches the regex '^([A-Z]):' so should work
+                $result | Should -Be 100GB
+            }
+        }
+    }
+
+    Context 'Real-world scenarios' {
+        It 'Returns actual free space for system drive' -Skip:(-not $IsWindows -and $PSVersionTable.PSEdition -ne 'Desktop') {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-PatDestinationFreeSpace -Path 'C:\'
+
+                # Should return a positive value for the actual system drive
+                $result | Should -BeGreaterThan 0
+            }
+        }
+
+        It 'Handles non-existent drive letter gracefully' {
+            InModuleScope PlexAutomationToolkit {
+                # Using a drive letter that is unlikely to exist
+                $result = Get-PatDestinationFreeSpace -Path 'Z:\NonExistent'
+
+                # Should return 0 without throwing
+                $result | Should -Be 0
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatDestinationFreeSpace.tests.ps1
+++ b/tests/Unit/Private/Get-PatDestinationFreeSpace.tests.ps1
@@ -95,8 +95,8 @@ Describe 'Get-PatDestinationFreeSpace' {
                 # Since we can't easily mock static .NET methods, we verify behavior
                 $result = Get-PatDestinationFreeSpace -Path '\\server\share\folder'
 
-                # Result will be 0 unless the path matches a mounted drive
-                # The return type is int when 0 is returned directly, or long for actual free space
+                # Result will be 0 (as a [long]) unless the path matches a mounted drive
+                # The function consistently returns a [long] value for both 0 and actual free space
                 $result | Should -Be 0
             }
         }

--- a/tests/Unit/Private/Get-PatSyncAddOperation.tests.ps1
+++ b/tests/Unit/Private/Get-PatSyncAddOperation.tests.ps1
@@ -1,0 +1,965 @@
+BeforeAll {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+
+    # Create temp directory for test files
+    $script:TestDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "PatSyncAddTests_$([Guid]::NewGuid().ToString('N'))"
+    New-Item -Path $script:TestDir -ItemType Directory -Force | Out-Null
+}
+
+AfterAll {
+    # Cleanup temp directory
+    if ($script:TestDir -and (Test-Path -Path $script:TestDir)) {
+        Remove-Item -Path $script:TestDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-PatSyncAddOperation' {
+    BeforeEach {
+        # Clean up test directory before each test
+        Get-ChildItem -Path $script:TestDir -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Context 'File does not exist (needs download)' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "Movies\$($MediaInfo.Title) ($($MediaInfo.Year))\$($MediaInfo.Title) ($($MediaInfo.Year)).$Extension"
+            }
+        }
+
+        It 'Returns add operation when file does not exist' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'The Matrix'
+                Type             = 'movie'
+                Year             = 1999
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 5GB
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.RatingKey | Should -Be 1001
+            $result.Title | Should -Be 'The Matrix'
+        }
+
+        It 'Returns operation with correct destination path' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Inception'
+                Type             = 'movie'
+                Year             = 2010
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 4GB
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.DestinationPath | Should -Match 'Inception \(2010\)'
+            $result.DestinationPath | Should -Match '\.mkv$'
+        }
+
+        It 'Returns operation with correct media size' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1234567890
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.MediaSize | Should -Be 1234567890
+        }
+    }
+
+    Context 'File exists with correct size (no download needed)' {
+        It 'Returns null when file exists with matching size' {
+            # Setup - create directory structure and file
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Test Movie (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $filePath = Join-Path -Path $movieDir -ChildPath 'Test Movie (2020).mkv'
+            $bytes = [byte[]]::new(1000)
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                $movieDir = Join-Path -Path $BasePath -ChildPath 'Movies\Test Movie (2020)'
+                return Join-Path -Path $movieDir -ChildPath 'Test Movie (2020).mkv'
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test Movie'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000  # Same as file size
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Correctly identifies existing file with matching size' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Existing (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $filePath = Join-Path -Path $movieDir -ChildPath 'Existing (2020).mkv'
+            $bytes = [byte[]]::new(500)
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                $movieDir = Join-Path -Path $BasePath -ChildPath 'Movies\Existing (2020)'
+                return Join-Path -Path $movieDir -ChildPath 'Existing (2020).mkv'
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Existing'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 500
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            # When file exists with correct size, function returns null (no download needed)
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'File exists with wrong size (needs download)' {
+        It 'Returns add operation when file size does not match' {
+            # Setup - create file with different size
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\Mismatch (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $filePath = Join-Path -Path $movieDir -ChildPath 'Mismatch (2020).mkv'
+            $bytes = [byte[]]::new(500)  # File is 500 bytes
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                $movieDir = Join-Path -Path $BasePath -ChildPath 'Movies\Mismatch (2020)'
+                return Join-Path -Path $movieDir -ChildPath 'Mismatch (2020).mkv'
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Mismatch'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000  # Expected size is 1000
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.MediaSize | Should -Be 1000
+        }
+
+        It 'Returns operation with expected size when local file has different size' {
+            # Setup
+            $movieDir = Join-Path -Path $script:TestDir -ChildPath 'Movies\SizeMismatch (2020)'
+            New-Item -Path $movieDir -ItemType Directory -Force | Out-Null
+
+            $filePath = Join-Path -Path $movieDir -ChildPath 'SizeMismatch (2020).mkv'
+            $bytes = [byte[]]::new(100)  # Local file is 100 bytes
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                $movieDir = Join-Path -Path $BasePath -ChildPath 'Movies\SizeMismatch (2020)'
+                return Join-Path -Path $movieDir -ChildPath 'SizeMismatch (2020).mkv'
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'SizeMismatch'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 200  # Server reports 200 bytes
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            # Size mismatch triggers download, so operation is returned
+            $result | Should -Not -BeNullOrEmpty
+            $result.MediaSize | Should -Be 200
+        }
+    }
+
+    Context 'Null/missing media info handling' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                return 'C:\test\movie.mkv'
+            }
+        }
+
+        It 'Returns null when Media array is null' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'No Media'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = $null
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when Media array is empty' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'Empty Media'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = @()
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when Part array is null' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'No Parts'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = @(
+                    [PSCustomObject]@{
+                        Part = $null
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when Part array is empty' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'Empty Parts'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = @(
+                    [PSCustomObject]@{
+                        Part = @()
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Handles missing media files gracefully' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'Missing Media'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = @()
+            }
+
+            $testDir = $script:TestDir
+
+            # Function returns null when no media files are found
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Handles missing media parts gracefully' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'Missing Parts'
+                Type      = 'movie'
+                Year      = 2020
+                Media     = @(
+                    [PSCustomObject]@{
+                        Part = @()
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            # Function returns null when no media parts are found
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Subtitle counting' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "Movies\Test\Test.$Extension"
+            }
+        }
+
+        It 'Counts external subtitles correctly' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'With Subtitles'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @(
+                                    [PSCustomObject]@{ StreamType = 3; External = $true },
+                                    [PSCustomObject]@{ StreamType = 3; External = $true },
+                                    [PSCustomObject]@{ StreamType = 3; External = $true }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.SubtitleCount | Should -Be 3
+        }
+
+        It 'Does not count embedded subtitles' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Embedded Subs'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @(
+                                    [PSCustomObject]@{ StreamType = 3; External = $false },  # Embedded
+                                    [PSCustomObject]@{ StreamType = 3; External = $true }    # External
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.SubtitleCount | Should -Be 1
+        }
+
+        It 'Does not count non-subtitle streams' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Mixed Streams'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @(
+                                    [PSCustomObject]@{ StreamType = 1; External = $false },  # Video
+                                    [PSCustomObject]@{ StreamType = 2; External = $false },  # Audio
+                                    [PSCustomObject]@{ StreamType = 3; External = $true },   # Subtitle
+                                    [PSCustomObject]@{ StreamType = 4; External = $false }   # Other
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.SubtitleCount | Should -Be 1
+        }
+
+        It 'Returns 0 when no streams exist' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'No Streams'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = $null
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.SubtitleCount | Should -Be 0
+        }
+
+        It 'Returns 0 when streams array is empty' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Empty Streams'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.SubtitleCount | Should -Be 0
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory MediaInfo parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncAddOperation
+                $parameter = $command.Parameters['MediaInfo']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'Has mandatory BasePath parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncAddOperation
+                $parameter = $command.Parameters['BasePath']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'BasePath validates not null or empty' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncAddOperation
+                $parameter = $command.Parameters['BasePath']
+
+                $validateAttribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] }
+                $validateAttribute | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Throws on empty BasePath' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey = 1001
+                Title     = 'Test'
+                Media     = @()
+            }
+
+            {
+                InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo } {
+                    Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath ''
+                }
+            } | Should -Throw
+        }
+    }
+
+    Context 'Operation object structure' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "Movies\Test (2020)\Test (2020).$Extension"
+            }
+        }
+
+        It 'Returns operation with correct PSTypeName' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.PSObject.TypeNames | Should -Contain 'PlexAutomationToolkit.SyncAddOperation'
+        }
+
+        It 'Returns operation with all required properties' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Full Movie'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/5678'
+                                Size      = 5000000000
+                                Container = 'mp4'
+                                Streams   = @(
+                                    [PSCustomObject]@{ StreamType = 3; External = $true }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.RatingKey | Should -Be 1001
+            $result.Title | Should -Be 'Full Movie'
+            $result.Type | Should -Be 'movie'
+            $result.Year | Should -Be 2020
+            $result.DestinationPath | Should -Not -BeNullOrEmpty
+            $result.MediaSize | Should -Be 5000000000
+            $result.SubtitleCount | Should -Be 1
+            $result.PartKey | Should -Be '/library/parts/5678'
+            $result.Container | Should -Be 'mp4'
+        }
+
+        It 'Includes TV show metadata for episodes' {
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 2001
+                Title            = 'Pilot'
+                Type             = 'episode'
+                Year             = $null
+                GrandparentTitle = 'Breaking Bad'
+                ParentIndex      = 1
+                Index            = 1
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/9999'
+                                Size      = 1GB
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.GrandparentTitle | Should -Be 'Breaking Bad'
+            $result.ParentIndex | Should -Be 1
+            $result.Index | Should -Be 1
+        }
+    }
+
+    Context 'Container/extension handling' {
+        It 'Uses Container from part when available' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "test.$Extension"
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = 'mp4'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.Container | Should -Be 'mp4'
+            $result.DestinationPath | Should -Match '\.mp4$'
+        }
+
+        It 'Defaults to mkv when Container is null' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "test.$Extension"
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = $null
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.DestinationPath | Should -Match '\.mkv$'
+        }
+
+        It 'Defaults to mkv when Container is empty string' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "test.$Extension"
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Test'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/1234'
+                                Size      = 1000
+                                Container = ''
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.DestinationPath | Should -Match '\.mkv$'
+        }
+    }
+
+    Context 'First media version selection' {
+        It 'Uses first media version when multiple versions exist' {
+            Mock -ModuleName PlexAutomationToolkit Get-PatMediaPath {
+                param($MediaInfo, $BasePath, $Extension)
+                return Join-Path -Path $BasePath -ChildPath "test.$Extension"
+            }
+
+            $mediaInfo = [PSCustomObject]@{
+                RatingKey        = 1001
+                Title            = 'Multi Version'
+                Type             = 'movie'
+                Year             = 2020
+                GrandparentTitle = $null
+                ParentIndex      = $null
+                Index            = $null
+                Media            = @(
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/first'
+                                Size      = 1000
+                                Container = 'mkv'
+                                Streams   = @()
+                            }
+                        )
+                    },
+                    [PSCustomObject]@{
+                        Part = @(
+                            [PSCustomObject]@{
+                                Key       = '/library/parts/second'
+                                Size      = 2000
+                                Container = 'mp4'
+                                Streams   = @()
+                            }
+                        )
+                    }
+                )
+            }
+
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ mediaInfo = $mediaInfo; testDir = $testDir } {
+                Get-PatSyncAddOperation -MediaInfo $mediaInfo -BasePath $testDir
+            }
+
+            $result.PartKey | Should -Be '/library/parts/first'
+            $result.MediaSize | Should -Be 1000
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatSyncRemoveOperation.tests.ps1
+++ b/tests/Unit/Private/Get-PatSyncRemoveOperation.tests.ps1
@@ -1,0 +1,652 @@
+BeforeAll {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+
+    # Create temp directory for test files
+    $script:TestDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "PatSyncRemoveTests_$([Guid]::NewGuid().ToString('N'))"
+    New-Item -Path $script:TestDir -ItemType Directory -Force | Out-Null
+}
+
+AfterAll {
+    # Cleanup temp directory
+    if ($script:TestDir -and (Test-Path -Path $script:TestDir)) {
+        Remove-Item -Path $script:TestDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Get-PatSyncRemoveOperation' {
+    BeforeEach {
+        # Clean up test directory before each test
+        Get-ChildItem -Path $script:TestDir -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Context 'Finding orphaned files' {
+        It 'Returns orphaned files not in expected paths' {
+            # Setup - create files
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $moviesDir -ChildPath 'Keep.mkv'
+            $file2 = Join-Path -Path $moviesDir -ChildPath 'Remove.mkv'
+            [System.IO.File]::WriteAllBytes($file1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($file2, [byte[]](4, 5, 6))
+
+            $expectedPaths = @{ $file1 = $true }
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Be $file2
+        }
+
+        It 'Returns empty operations when all files are expected' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $moviesDir -ChildPath 'Expected1.mkv'
+            $file2 = Join-Path -Path $moviesDir -ChildPath 'Expected2.mkv'
+            [System.IO.File]::WriteAllBytes($file1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($file2, [byte[]](4, 5, 6))
+
+            $expectedPaths = @{ $file1 = $true; $file2 = $true }
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.Operations | Should -HaveCount 0
+            $result.TotalBytes | Should -Be 0
+        }
+
+        It 'Returns all files when expected paths is empty' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $moviesDir -ChildPath 'Orphan1.mkv'
+            $file2 = Join-Path -Path $moviesDir -ChildPath 'Orphan2.mp4'
+            [System.IO.File]::WriteAllBytes($file1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($file2, [byte[]](4, 5, 6, 7))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.Operations | Should -HaveCount 2
+        }
+
+        It 'Calculates total bytes correctly' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $moviesDir -ChildPath 'Orphan1.mkv'
+            $file2 = Join-Path -Path $moviesDir -ChildPath 'Orphan2.mkv'
+
+            # Create files with known sizes
+            $bytes1 = [byte[]]::new(1000)
+            $bytes2 = [byte[]]::new(2000)
+            [System.IO.File]::WriteAllBytes($file1, $bytes1)
+            [System.IO.File]::WriteAllBytes($file2, $bytes2)
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.TotalBytes | Should -Be 3000
+        }
+    }
+
+    Context 'Excluding expected paths' {
+        It 'Excludes files in expected paths hashtable' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $expectedFile = Join-Path -Path $moviesDir -ChildPath 'Expected.mkv'
+            $orphanFile = Join-Path -Path $moviesDir -ChildPath 'Orphan.mkv'
+            [System.IO.File]::WriteAllBytes($expectedFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($orphanFile, [byte[]](4, 5, 6))
+
+            $expectedPaths = @{ $expectedFile = $true }
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Be $orphanFile
+        }
+
+        It 'Matches exact paths in expected paths hashtable' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $moviesDir -ChildPath 'Movie.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            # Use exact path in expected paths
+            $expectedPaths = @{ $file = $true }
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert - Exact match means no orphans
+            $result.Operations | Should -HaveCount 0
+        }
+    }
+
+    Context 'Different media types' {
+        It 'Sets Type to movie for movie media type' {
+            # Setup
+            $moviesDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $moviesDir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $moviesDir -ChildPath 'Movie.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Assert
+            $result.Operations[0].Type | Should -Be 'movie'
+        }
+
+        It 'Sets Type to episode for episode media type' {
+            # Setup
+            $tvDir = Join-Path -Path $script:TestDir -ChildPath 'TV Shows'
+            New-Item -Path $tvDir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $tvDir -ChildPath 'Episode.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            # Act
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'episode'
+            }
+
+            # Assert
+            $result.Operations[0].Type | Should -Be 'episode'
+        }
+
+        It 'Throws on invalid media type' {
+            $testDir = $script:TestDir
+            $expectedPaths = @{}
+
+            {
+                InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                    Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'invalid'
+                }
+            } | Should -Throw
+        }
+    }
+
+    Context 'Non-existent folder handling' {
+        It 'Returns empty operations for non-existent folder' {
+            $nonExistentPath = Join-Path -Path $script:TestDir -ChildPath 'NonExistent'
+            $expectedPaths = @{}
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ nonExistentPath = $nonExistentPath; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $nonExistentPath -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 0
+            $result.TotalBytes | Should -Be 0
+        }
+
+        It 'Returns hashtable with Operations and TotalBytes keys for non-existent folder' {
+            $nonExistentPath = Join-Path -Path $script:TestDir -ChildPath 'DoesNotExist'
+            $expectedPaths = @{}
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ nonExistentPath = $nonExistentPath; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $nonExistentPath -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Keys | Should -Contain 'Operations'
+            $result.Keys | Should -Contain 'TotalBytes'
+        }
+    }
+
+    Context 'Various media file extensions' {
+        It 'Finds MKV files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.mkv$'
+        }
+
+        It 'Finds MP4 files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.mp4'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.mp4$'
+        }
+
+        It 'Finds AVI files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.avi'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.avi$'
+        }
+
+        It 'Finds M4V files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.m4v'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.m4v$'
+        }
+
+        It 'Finds MOV files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.mov'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.mov$'
+        }
+
+        It 'Finds TS files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.ts'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.ts$'
+        }
+
+        It 'Finds WMV files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Video.wmv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.wmv$'
+        }
+
+        It 'Ignores non-media files' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $mediaFile = Join-Path -Path $dir -ChildPath 'Video.mkv'
+            $textFile = Join-Path -Path $dir -ChildPath 'readme.txt'
+            $subtitleFile = Join-Path -Path $dir -ChildPath 'Video.srt'
+            $imageFile = Join-Path -Path $dir -ChildPath 'poster.jpg'
+
+            [System.IO.File]::WriteAllBytes($mediaFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($textFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($subtitleFile, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($imageFile, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            # Should only find the MKV file
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Match '\.mkv$'
+        }
+
+        It 'Finds all supported extensions in one scan' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Media'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $extensions = @('mkv', 'mp4', 'avi', 'm4v', 'mov', 'ts', 'wmv')
+            foreach ($ext in $extensions) {
+                $file = Join-Path -Path $dir -ChildPath "Video.$ext"
+                [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+            }
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 7
+        }
+    }
+
+    Context 'Recursive scanning' {
+        It 'Finds files in subdirectories' {
+            # Setup nested structure
+            $rootDir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            $subDir1 = Join-Path -Path $rootDir -ChildPath 'Action'
+            $subDir2 = Join-Path -Path $rootDir -ChildPath 'Comedy\2020'
+            New-Item -Path $subDir1 -ItemType Directory -Force | Out-Null
+            New-Item -Path $subDir2 -ItemType Directory -Force | Out-Null
+
+            $file1 = Join-Path -Path $rootDir -ChildPath 'Root.mkv'
+            $file2 = Join-Path -Path $subDir1 -ChildPath 'Action.mkv'
+            $file3 = Join-Path -Path $subDir2 -ChildPath 'Comedy.mkv'
+
+            [System.IO.File]::WriteAllBytes($file1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($file2, [byte[]](4, 5, 6))
+            [System.IO.File]::WriteAllBytes($file3, [byte[]](7, 8, 9))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 3
+        }
+    }
+
+    Context 'Operation object structure' {
+        It 'Returns operations with correct PSTypeName' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Movie.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations[0].PSObject.TypeNames | Should -Contain 'PlexAutomationToolkit.SyncRemoveOperation'
+        }
+
+        It 'Returns operations with Path property' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Movie.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations[0].Path | Should -Be $file
+        }
+
+        It 'Returns operations with Size property' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Movie.mkv'
+            $bytes = [byte[]]::new(500)
+            [System.IO.File]::WriteAllBytes($file, $bytes)
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations[0].Size | Should -Be 500
+        }
+
+        It 'Returns operations with Type property' {
+            $dir = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            New-Item -Path $dir -ItemType Directory -Force | Out-Null
+
+            $file = Join-Path -Path $dir -ChildPath 'Movie.mkv'
+            [System.IO.File]::WriteAllBytes($file, [byte[]](1, 2, 3))
+
+            $expectedPaths = @{}
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations[0].Type | Should -Be 'movie'
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Has mandatory FolderPath parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncRemoveOperation
+                $parameter = $command.Parameters['FolderPath']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'Has mandatory ExpectedPaths parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncRemoveOperation
+                $parameter = $command.Parameters['ExpectedPaths']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'Has mandatory MediaType parameter' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncRemoveOperation
+                $parameter = $command.Parameters['MediaType']
+
+                $parameter | Should -Not -BeNullOrEmpty
+                $parameter.Attributes.Mandatory | Should -Contain $true
+            }
+        }
+
+        It 'MediaType parameter has ValidateSet for movie and episode' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncRemoveOperation
+                $parameter = $command.Parameters['MediaType']
+
+                $validateSet = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+                $validateSet | Should -Not -BeNullOrEmpty
+                $validateSet.ValidValues | Should -Contain 'movie'
+                $validateSet.ValidValues | Should -Contain 'episode'
+            }
+        }
+
+        It 'FolderPath validates not null or empty' {
+            InModuleScope PlexAutomationToolkit {
+                $command = Get-Command Get-PatSyncRemoveOperation
+                $parameter = $command.Parameters['FolderPath']
+
+                $validateAttribute = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] }
+                $validateAttribute | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Throws on empty FolderPath' {
+            $expectedPaths = @{}
+
+            {
+                InModuleScope PlexAutomationToolkit -Parameters @{ expectedPaths = $expectedPaths } {
+                    Get-PatSyncRemoveOperation -FolderPath '' -ExpectedPaths $expectedPaths -MediaType 'movie'
+                }
+            } | Should -Throw
+        }
+    }
+
+    Context 'Real-world sync scenarios' {
+        It 'Handles typical movie library structure' {
+            # Setup Plex-style movie structure
+            $moviesRoot = Join-Path -Path $script:TestDir -ChildPath 'Movies'
+            $movie1Dir = Join-Path -Path $moviesRoot -ChildPath 'The Matrix (1999)'
+            $movie2Dir = Join-Path -Path $moviesRoot -ChildPath 'Inception (2010)'
+            $movie3Dir = Join-Path -Path $moviesRoot -ChildPath 'Old Movie (2000)'
+
+            New-Item -Path $movie1Dir -ItemType Directory -Force | Out-Null
+            New-Item -Path $movie2Dir -ItemType Directory -Force | Out-Null
+            New-Item -Path $movie3Dir -ItemType Directory -Force | Out-Null
+
+            $matrix = Join-Path -Path $movie1Dir -ChildPath 'The Matrix (1999).mkv'
+            $inception = Join-Path -Path $movie2Dir -ChildPath 'Inception (2010).mkv'
+            $oldMovie = Join-Path -Path $movie3Dir -ChildPath 'Old Movie (2000).mkv'
+
+            [System.IO.File]::WriteAllBytes($matrix, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($inception, [byte[]](4, 5, 6))
+            [System.IO.File]::WriteAllBytes($oldMovie, [byte[]](7, 8, 9))
+
+            # Only keep Matrix and Inception
+            $expectedPaths = @{
+                $matrix    = $true
+                $inception = $true
+            }
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'movie'
+            }
+
+            $result.Operations | Should -HaveCount 1
+            $result.Operations[0].Path | Should -Be $oldMovie
+        }
+
+        It 'Handles typical TV show structure' {
+            # Setup Plex-style TV structure
+            $tvRoot = Join-Path -Path $script:TestDir -ChildPath 'TV Shows'
+            $showDir = Join-Path -Path $tvRoot -ChildPath 'Breaking Bad'
+            $season1 = Join-Path -Path $showDir -ChildPath 'Season 01'
+            $season2 = Join-Path -Path $showDir -ChildPath 'Season 02'
+
+            New-Item -Path $season1 -ItemType Directory -Force | Out-Null
+            New-Item -Path $season2 -ItemType Directory -Force | Out-Null
+
+            $ep1 = Join-Path -Path $season1 -ChildPath 'Breaking Bad - S01E01 - Pilot.mkv'
+            $ep2 = Join-Path -Path $season1 -ChildPath 'Breaking Bad - S01E02 - Cat.mkv'
+            $ep3 = Join-Path -Path $season2 -ChildPath 'Breaking Bad - S02E01 - Seven Thirty-Seven.mkv'
+
+            [System.IO.File]::WriteAllBytes($ep1, [byte[]](1, 2, 3))
+            [System.IO.File]::WriteAllBytes($ep2, [byte[]](4, 5, 6))
+            [System.IO.File]::WriteAllBytes($ep3, [byte[]](7, 8, 9))
+
+            # Only keep S01E01
+            $expectedPaths = @{ $ep1 = $true }
+            $testDir = $script:TestDir
+
+            $result = InModuleScope PlexAutomationToolkit -Parameters @{ testDir = $testDir; expectedPaths = $expectedPaths } {
+                Get-PatSyncRemoveOperation -FolderPath $testDir -ExpectedPaths $expectedPaths -MediaType 'episode'
+            }
+
+            $result.Operations | Should -HaveCount 2
+            $result.Operations.Path | Should -Contain $ep2
+            $result.Operations.Path | Should -Contain $ep3
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts 3 private helper functions from `Get-PatSyncPlan` to improve testability and reduce complexity
- Reduces `Get-PatSyncPlan.ps1` from 359 lines to 255 lines (29% reduction)
- Uses existing `Build-PatServerSplat` helper to eliminate duplicate server parameter logic
- Fixes O(n²) array performance by using `List<T>` instead of `+=`
- Adds 86 new unit tests for the extracted functions

### Extracted Functions

| Function | Purpose |
|----------|---------|
| `Get-PatDestinationFreeSpace` | Gets available free space at a destination path (handles drive letters and UNC paths) |
| `Get-PatSyncRemoveOperation` | Scans folders for orphaned media files to remove during sync |
| `Get-PatSyncAddOperation` | Determines if a media item needs downloading (checks file existence and size) |

### Performance Improvements

- Replaced `$array += $item` with `[List[PSCustomObject]].Add()` for O(n) instead of O(n²) operations
- Reused `Build-PatServerSplat` helper instead of duplicating server parameter logic

## Test plan

- [x] All 1728 existing tests pass
- [x] 86 new tests added for extracted functions
- [x] Drive letter and UNC path handling tested
- [x] File existence and size checking tested
- [x] Orphaned file detection tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)