### PR TITLE
refactor: extract helper functions from Add-PatServer

### DIFF
--- a/PlexAutomationToolkit/Private/Get-PatDetectedLocalUri.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatDetectedLocalUri.ps1
@@ -1,0 +1,84 @@
+function Get-PatDetectedLocalUri {
+    <#
+    .SYNOPSIS
+        Detects the local network URI for a Plex server from the Plex.tv API.
+
+    .DESCRIPTION
+        Internal helper function that queries the Plex.tv API to find local network
+        connections for a server. Returns the best local URI (preferring HTTPS) or
+        $null if no local connection is found.
+
+    .PARAMETER ServerUri
+        The primary server URI to get the machine identifier from.
+
+    .PARAMETER Token
+        The Plex authentication token for API access.
+
+    .OUTPUTS
+        System.String or $null
+        Returns the detected local URI, or $null if none found or detection fails.
+
+    .EXAMPLE
+        Get-PatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'abc123'
+
+        Returns the local URI if detected, such as 'http://192.168.1.100:32400'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServerUri,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Token
+    )
+
+    process {
+        Write-Verbose "Attempting to detect local URI from Plex.tv API"
+
+        try {
+            # First, get the server's machine identifier
+            $serverIdentity = Get-PatServerIdentity -ServerUri $ServerUri -Token $Token -ErrorAction Stop
+            Write-Verbose "Server machineIdentifier: $($serverIdentity.MachineIdentifier)"
+
+            # Query Plex.tv for all connections to this server
+            $connections = Get-PatServerConnection -MachineIdentifier $serverIdentity.MachineIdentifier -Token $Token -ErrorAction Stop
+
+            if (-not $connections -or $connections.Count -eq 0) {
+                Write-Verbose "No connections found in Plex.tv API response"
+                return $null
+            }
+
+            # Find a local, non-relay connection (prefer HTTPS if available)
+            $localConnections = $connections | Where-Object { $_.Local -eq $true -and $_.Relay -ne $true }
+
+            if (-not $localConnections) {
+                Write-Verbose "No local (non-relay) connections found for this server"
+                return $null
+            }
+
+            # Prefer HTTPS local connection, fall back to HTTP
+            $preferredLocal = $localConnections | Where-Object { $_.Protocol -eq 'https' } | Select-Object -First 1
+            if (-not $preferredLocal) {
+                $preferredLocal = $localConnections | Select-Object -First 1
+            }
+
+            if ($preferredLocal -and $preferredLocal.Uri -ne $ServerUri) {
+                Write-Verbose "Detected local URI: $($preferredLocal.Uri)"
+                return $preferredLocal.Uri
+            }
+            else {
+                Write-Verbose "No distinct local URI found (may already be using local connection)"
+                return $null
+            }
+        }
+        catch {
+            Write-Warning "Failed to detect local URI: $($_.Exception.Message)"
+            return $null
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Test-PatHttpsAvailability.ps1
+++ b/PlexAutomationToolkit/Private/Test-PatHttpsAvailability.ps1
@@ -1,0 +1,104 @@
+function Test-PatHttpsAvailability {
+    <#
+    .SYNOPSIS
+        Tests if HTTPS is available for a given HTTP URI.
+
+    .DESCRIPTION
+        Internal helper function that probes whether a server supports HTTPS connections.
+        Handles PowerShell version differences for certificate validation and uses
+        mutex-based locking for thread safety in PowerShell 5.1.
+
+    .PARAMETER HttpUri
+        The HTTP URI to test for HTTPS availability.
+
+    .OUTPUTS
+        System.Boolean
+        Returns $true if HTTPS is available (including when auth is required), $false otherwise.
+
+    .EXAMPLE
+        Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+        Returns $true if the server responds to HTTPS requests.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidatePattern('^http://')]
+        [string]
+        $HttpUri
+    )
+
+    process {
+        $httpsUri = $HttpUri -replace '^http://', 'https://'
+        Write-Verbose "Checking if HTTPS is available at $httpsUri"
+
+        $httpsAvailable = $false
+        $certValidationCallback = $null
+        $certCallbackChanged = $false
+        $certMutex = $null
+
+        try {
+            $testUri = Join-PatUri -BaseUri $httpsUri -Endpoint '/'
+            # Build request params - handle certificate skip for PS version compatibility
+            $requestParams = @{
+                Uri         = $testUri
+                TimeoutSec  = 5
+                ErrorAction = 'Stop'
+            }
+
+            # Skip certificate validation for self-signed certs (common with Plex)
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                # PowerShell 6.0+ supports SkipCertificateCheck parameter
+                $requestParams['SkipCertificateCheck'] = $true
+            }
+            else {
+                # PowerShell 5.1 requires ServerCertificateValidationCallback
+                # Use a named mutex to prevent race conditions when multiple calls modify the global callback
+                $certMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+                $mutexAcquired = $certMutex.WaitOne(10000) # 10 second timeout
+                if (-not $mutexAcquired) {
+                    # Could not acquire mutex - skip HTTPS check rather than risk race condition
+                    Write-Verbose "Could not acquire certificate callback mutex, skipping HTTPS availability check"
+                    $certMutex.Dispose()
+                    $certMutex = $null
+                    return $false
+                }
+                else {
+                    $certValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+                    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+                    $certCallbackChanged = $true
+                }
+            }
+
+            # Only proceed with HTTPS check if we either have PS6+ or successfully acquired mutex
+            if ($PSVersionTable.PSVersion.Major -ge 6 -or $certCallbackChanged) {
+                $null = Invoke-RestMethod @requestParams
+                $httpsAvailable = $true
+            }
+        }
+        catch {
+            # 401/403 means HTTPS works, just needs auth - that's fine
+            if ($_.Exception.Response.StatusCode.value__ -in @(401, 403)) {
+                $httpsAvailable = $true
+            }
+            else {
+                Write-Verbose "HTTPS not available: $($_.Exception.Message)"
+            }
+        }
+        finally {
+            # Restore original certificate validation callback if we changed it
+            if ($certCallbackChanged) {
+                [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $certValidationCallback
+            }
+            # Release mutex if acquired
+            if ($certMutex) {
+                $certMutex.ReleaseMutex()
+                $certMutex.Dispose()
+            }
+        }
+
+        return $httpsAvailable
+    }
+}

--- a/tests/Unit/Private/Get-PatDetectedLocalUri.tests.ps1
+++ b/tests/Unit/Private/Get-PatDetectedLocalUri.tests.ps1
@@ -1,0 +1,1102 @@
+BeforeAll {
+    # Import the module from source
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+
+    # Get reference to private function
+    $script:GetPatDetectedLocalUri = & (Get-Module PlexAutomationToolkit) { Get-Command Get-PatDetectedLocalUri }
+}
+
+Describe 'Get-PatDetectedLocalUri' {
+
+    Context 'Parameter validation' {
+        It 'Requires ServerUri parameter' {
+            { & $script:GetPatDetectedLocalUri -Token 'test-token' } | Should -Throw
+        }
+
+        It 'Requires Token parameter' {
+            { & $script:GetPatDetectedLocalUri -ServerUri 'http://192.168.1.100:32400' } | Should -Throw
+        }
+
+        It 'Rejects empty ServerUri' {
+            { & $script:GetPatDetectedLocalUri -ServerUri '' -Token 'test-token' } | Should -Throw
+        }
+
+        It 'Rejects empty Token' {
+            { & $script:GetPatDetectedLocalUri -ServerUri 'http://192.168.1.100:32400' -Token '' } | Should -Throw
+        }
+
+        It 'Rejects null ServerUri' {
+            { & $script:GetPatDetectedLocalUri -ServerUri $null -Token 'test-token' } | Should -Throw
+        }
+
+        It 'Rejects null Token' {
+            { & $script:GetPatDetectedLocalUri -ServerUri 'http://192.168.1.100:32400' -Token $null } | Should -Throw
+        }
+    }
+
+    Context 'Successful detection of local URI' {
+        BeforeEach {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                        FriendlyName      = 'Test Server'
+                        Version           = '1.32.0.6918'
+                        Platform          = 'Linux'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            IPv6     = $false
+                            Protocol = 'http'
+                            Address  = '192.168.1.100'
+                            Port     = 32400
+                        }
+                    )
+                }
+            }
+        }
+
+        It 'Returns local URI when different from ServerUri' {
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'http://192.168.1.100:32400'
+        }
+
+        It 'Calls Get-PatServerIdentity with correct parameters' {
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Get-PatServerIdentity -Times 1 -ParameterFilter {
+                    $ServerUri -eq 'https://plex.example.com:32400' -and
+                    $Token -eq 'test-token'
+                }
+            }
+        }
+
+        It 'Calls Get-PatServerConnection with machine identifier' {
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Get-PatServerConnection -Times 1 -ParameterFilter {
+                    $MachineIdentifier -eq 'abc123-machine-id' -and
+                    $Token -eq 'test-token'
+                }
+            }
+        }
+
+        It 'Returns string type' {
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeOfType [string]
+        }
+    }
+
+    Context 'Prefers HTTPS over HTTP' {
+        It 'Returns HTTPS connection when both HTTP and HTTPS available' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                        FriendlyName      = 'Test Server'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'https://192.168.1.100:32400'
+        }
+
+        It 'Returns first HTTPS connection when multiple HTTPS connections available' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                        FriendlyName      = 'Test Server'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.101:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'https://192.168.1.100:32400'
+        }
+
+        It 'Returns HTTP connection when HTTPS not available' {
+            $mockConnectionsHttpOnly = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                        FriendlyName      = 'Test Server'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'http://192.168.1.100:32400'
+        }
+    }
+
+    Context 'Returns null when no connections found' {
+        It 'Returns null when connections array is empty' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { return @() }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when connections is null' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { return $null }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Returns null when no local connections found' {
+        It 'Returns null when all connections are remote' {
+            $mockRemoteConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://plex.example.com:32400'
+                    Local    = $false
+                    Relay    = $false
+                    Protocol = 'https'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'https://plex2.example.com:32400'
+                    Local    = $false
+                    Relay    = $false
+                    Protocol = 'https'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://plex.example.com:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://plex2.example.com:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when Local property is false' {
+            $mockNonLocalConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $false
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Returns null when only relay connections found' {
+        It 'Returns null when all connections are relay' {
+            $mockRelayConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://relay1.plex.direct:32400'
+                    Local    = $false
+                    Relay    = $true
+                    Protocol = 'https'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'https://relay2.plex.direct:32400'
+                    Local    = $false
+                    Relay    = $true
+                    Protocol = 'https'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://relay1.plex.direct:32400'
+                            Local    = $false
+                            Relay    = $true
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://relay2.plex.direct:32400'
+                            Local    = $false
+                            Relay    = $true
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when connection is local but also relay' {
+            $mockLocalRelayConnection = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $true
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $true
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns local non-relay connection when mixed relay and non-relay available' {
+            $mockMixedConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://relay.plex.direct:32400'
+                    Local    = $false
+                    Relay    = $true
+                    Protocol = 'https'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://relay.plex.direct:32400'
+                            Local    = $false
+                            Relay    = $true
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'http://192.168.1.100:32400'
+        }
+    }
+
+    Context 'Returns null when local URI matches server URI' {
+        It 'Returns null when detected local URI is same as ServerUri' {
+            $mockSameUriConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'http://192.168.1.100:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null when preferred HTTPS local URI matches ServerUri' {
+            $mockHttpsMatchConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'https://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'https'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://192.168.1.100:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns different local URI when HTTP variant available but HTTPS is ServerUri' {
+            $mockDifferentProtocolConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://192.168.1.100:32400' -Token 'test-token'
+
+            $result | Should -Be 'http://192.168.1.100:32400'
+        }
+    }
+
+    Context 'Error handling when Get-PatServerIdentity fails' {
+        It 'Returns null and writes warning when Get-PatServerIdentity throws' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity { throw 'Connection refused' }
+                Mock Write-Warning { }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Writes warning message when Get-PatServerIdentity fails' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity { throw 'Network timeout' }
+                Mock Write-Warning { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+                    $Message -match 'Failed to detect local URI'
+                }
+            }
+        }
+
+        It 'Includes original error message in warning' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity { throw 'Authentication failed: 401 Unauthorized' }
+                Mock Write-Warning { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+                    $Message -match 'Authentication failed: 401 Unauthorized'
+                }
+            }
+        }
+    }
+
+    Context 'Error handling when Get-PatServerConnection fails' {
+        It 'Returns null and writes warning when Get-PatServerConnection throws' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { throw 'API error' }
+                Mock Write-Warning { }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Writes warning message when Get-PatServerConnection fails' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { throw 'Plex.tv API unavailable' }
+                Mock Write-Warning { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+                    $Message -match 'Failed to detect local URI'
+                }
+            }
+        }
+
+        It 'Includes original error message in warning' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { throw '403 Forbidden' }
+                Mock Write-Warning { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+                    $Message -match '403 Forbidden'
+                }
+            }
+        }
+    }
+
+    Context 'Verbose output' {
+        It 'Writes verbose message at start of detection' {
+            $mockConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'Attempting to detect local URI'
+                }
+            }
+        }
+
+        It 'Writes verbose message with machine identifier' {
+            $mockConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'abc123-machine-id'
+                }
+            }
+        }
+
+        It 'Writes verbose message when local URI detected' {
+            $mockConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'Detected local URI.*192.168.1.100'
+                }
+            }
+        }
+
+        It 'Writes verbose message when no connections found' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { return @() }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'No connections found'
+                }
+            }
+        }
+
+        It 'Writes verbose message when no local connections found' {
+            $mockRemoteConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://plex.example.com:32400'
+                    Local    = $false
+                    Relay    = $false
+                    Protocol = 'https'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://plex.example.com:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://plex2.example.com:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'No local.*non-relay.*connections found'
+                }
+            }
+        }
+
+        It 'Writes verbose message when local URI matches server URI' {
+            $mockSameUriConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+                Mock Write-Verbose { }
+            }
+
+            & $script:GetPatDetectedLocalUri -ServerUri 'http://192.168.1.100:32400' -Token 'test-token' -Verbose
+
+            & (Get-Module PlexAutomationToolkit) {
+                Should -Invoke Write-Verbose -ParameterFilter {
+                    $Message -match 'No distinct local URI found'
+                }
+            }
+        }
+    }
+
+    Context 'Complex scenarios' {
+        It 'Filters correctly with mixed local, remote, and relay connections' {
+            $mockComplexConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://relay.plex.direct:32400'
+                    Local    = $false
+                    Relay    = $true
+                    Protocol = 'https'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'https://plex.example.com:32400'
+                    Local    = $false
+                    Relay    = $false
+                    Protocol = 'https'
+                },
+                [PSCustomObject]@{
+                    Uri      = 'https://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'https'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://relay.plex.direct:32400'
+                            Local    = $false
+                            Relay    = $true
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://plex.example.com:32400'
+                            Local    = $false
+                            Relay    = $false
+                            Protocol = 'https'
+                        },
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'https://192.168.1.100:32400'
+        }
+
+        It 'Works with IPv6 local connections' {
+            $mockIpv6Connections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://[fe80::1]:32400'
+                    Local    = $true
+                    Relay    = $false
+                    IPv6     = $true
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://[fe80::1]:32400'
+                            Local    = $true
+                            Relay    = $false
+                            IPv6     = $true
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'http://[fe80::1]:32400'
+        }
+
+        It 'Handles connections with different ports' {
+            $mockDifferentPortConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'https://192.168.1.100:8443'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'https'
+                    Port     = 8443
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'https://192.168.1.100:8443'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'https'
+                            Port     = 8443
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -Be 'https://192.168.1.100:8443'
+        }
+    }
+
+    Context 'Output type validation' {
+        It 'Returns string when local URI found' {
+            $mockConnections = @(
+                [PSCustomObject]@{
+                    Uri      = 'http://192.168.1.100:32400'
+                    Local    = $true
+                    Relay    = $false
+                    Protocol = 'http'
+                }
+            )
+
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection {
+                    return @(
+                        [PSCustomObject]@{
+                            Uri      = 'http://192.168.1.100:32400'
+                            Local    = $true
+                            Relay    = $false
+                            Protocol = 'http'
+                        }
+                    )
+                }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeOfType [string]
+            $result | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Returns null type when no local URI found' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { return @() }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null type on error' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity { throw 'Error' }
+                Mock Write-Warning { }
+            }
+
+            $result = & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'ErrorAction Stop behavior' {
+        It 'Catches errors when Get-PatServerIdentity called with ErrorAction Stop' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity { throw 'Server error' }
+                Mock Write-Warning { }
+            }
+
+            # Should not throw because function catches the error
+            { & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' } |
+                Should -Not -Throw
+        }
+
+        It 'Catches errors when Get-PatServerConnection called with ErrorAction Stop' {
+            & (Get-Module PlexAutomationToolkit) {
+                Mock Get-PatServerIdentity {
+                    return [PSCustomObject]@{
+                        MachineIdentifier = 'abc123-machine-id'
+                    }
+                }
+                Mock Get-PatServerConnection { throw 'API error' }
+                Mock Write-Warning { }
+            }
+
+            # Should not throw because function catches the error
+            { & $script:GetPatDetectedLocalUri -ServerUri 'https://plex.example.com:32400' -Token 'test-token' } |
+                Should -Not -Throw
+        }
+    }
+}

--- a/tests/Unit/Private/Test-PatHttpsAvailability.tests.ps1
+++ b/tests/Unit/Private/Test-PatHttpsAvailability.tests.ps1
@@ -1,0 +1,608 @@
+BeforeDiscovery {
+    # Check PowerShell version for skipping version-specific tests
+    $script:IsPS6Plus = $PSVersionTable.PSVersion.Major -ge 6
+    $script:IsPS51 = $PSVersionTable.PSVersion.Major -lt 6
+}
+
+BeforeAll {
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+
+    # Import required helper functions
+    . (Join-Path $ModuleRoot 'Private\Join-PatUri.ps1')
+    . (Join-Path $ModuleRoot 'Private\Test-PatHttpsAvailability.ps1')
+}
+
+Describe 'Test-PatHttpsAvailability' {
+    Context 'Parameter validation' {
+        It 'Requires HttpUri parameter' {
+            { Test-PatHttpsAvailability } | Should -Throw
+        }
+
+        It 'Rejects null HttpUri' {
+            { Test-PatHttpsAvailability -HttpUri $null } | Should -Throw
+        }
+
+        It 'Rejects empty HttpUri' {
+            { Test-PatHttpsAvailability -HttpUri '' } | Should -Throw
+        }
+
+        It 'Rejects HTTPS URIs' {
+            { Test-PatHttpsAvailability -HttpUri 'https://plex.local:32400' } | Should -Throw
+        }
+
+        It 'Accepts HTTP URIs' {
+            Mock Invoke-RestMethod { return @{} }
+            { Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400' } | Should -Not -Throw
+        }
+
+        It 'Accepts HTTP URIs with different ports' {
+            Mock Invoke-RestMethod { return @{} }
+            { Test-PatHttpsAvailability -HttpUri 'http://192.168.1.100:8080' } | Should -Not -Throw
+        }
+    }
+
+    Context 'HTTPS connection succeeds' {
+        BeforeEach {
+            Mock Invoke-RestMethod {
+                return [PSCustomObject]@{
+                    machineIdentifier = 'test-machine-id'
+                }
+            }
+        }
+
+        It 'Returns $true when HTTPS responds successfully' {
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+
+        It 'Converts HTTP to HTTPS in request' {
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://plex.local:32400/'
+            }
+        }
+
+        It 'Uses 5 second timeout' {
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $TimeoutSec -eq 5
+            }
+        }
+
+        It 'Uses ErrorAction Stop' {
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $ErrorAction -eq 'Stop'
+            }
+        }
+
+        It 'Handles different HTTP ports' {
+            Test-PatHttpsAvailability -HttpUri 'http://192.168.1.100:8080'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://192.168.1.100:8080/'
+            }
+        }
+    }
+
+    Context 'HTTPS returns authentication required (401/403)' {
+        It 'Returns $true when HTTPS returns 401 Unauthorized' {
+            Mock Invoke-RestMethod {
+                $response = New-Object System.Net.Http.HttpResponseMessage
+                $response.StatusCode = 401
+                $exception = [System.Net.Http.HttpRequestException]::new('Unauthorized')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+
+        It 'Returns $true when HTTPS returns 403 Forbidden' {
+            Mock Invoke-RestMethod {
+                $response = New-Object System.Net.Http.HttpResponseMessage
+                $response.StatusCode = 403
+                $exception = [System.Net.Http.HttpRequestException]::new('Forbidden')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+
+        It 'Returns $true when HTTPS returns 401 with WebException' {
+            Mock Invoke-RestMethod {
+                $response = [PSCustomObject]@{
+                    StatusCode = [PSCustomObject]@{
+                        value__ = 401
+                    }
+                }
+                $exception = [System.InvalidOperationException]::new('401 Unauthorized')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+
+        It 'Returns $true when HTTPS returns 403 with WebException' {
+            Mock Invoke-RestMethod {
+                $response = [PSCustomObject]@{
+                    StatusCode = [PSCustomObject]@{
+                        value__ = 403
+                    }
+                }
+                $exception = [System.InvalidOperationException]::new('403 Forbidden')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+    }
+
+    Context 'HTTPS connection fails' {
+        It 'Returns $false when HTTPS connection is refused' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('Connection refused')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Returns $false when HTTPS times out' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('The operation has timed out')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Returns $false when HTTPS returns 404' {
+            Mock Invoke-RestMethod {
+                $response = [PSCustomObject]@{
+                    StatusCode = [PSCustomObject]@{
+                        value__ = 404
+                    }
+                }
+                $exception = [System.InvalidOperationException]::new('404 Not Found')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Returns $false when HTTPS returns 500' {
+            Mock Invoke-RestMethod {
+                $response = [PSCustomObject]@{
+                    StatusCode = [PSCustomObject]@{
+                        value__ = 500
+                    }
+                }
+                $exception = [System.InvalidOperationException]::new('500 Internal Server Error')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $response -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Returns $false when DNS resolution fails' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('No such host is known')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://nonexistent.local:32400'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Returns $false on SSL/TLS handshake failure' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('The SSL connection could not be established')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'PowerShell 6+ certificate handling' -Skip:(-not $script:IsPS6Plus) {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Uses SkipCertificateCheck parameter on PowerShell 6+' {
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $SkipCertificateCheck -eq $true
+            }
+        }
+
+        It 'Does not modify ServerCertificateValidationCallback on PowerShell 6+' {
+            $originalCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Be $originalCallback
+        }
+
+        It 'Does not use mutex on PowerShell 6+' {
+            # If we're on PS6+, the function should not attempt to create a mutex
+            # We can verify this by checking that no mutex-related errors occur
+            { Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400' } | Should -Not -Throw
+        }
+    }
+
+    Context 'PowerShell 5.1 certificate handling' -Skip:(-not $script:IsPS51) {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Does not use SkipCertificateCheck parameter on PowerShell 5.1' {
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                -not $PSBoundParameters.ContainsKey('SkipCertificateCheck')
+            }
+        }
+
+        It 'Modifies ServerCertificateValidationCallback on PowerShell 5.1' {
+            # Store original callback
+            $originalCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+
+            # Set it to null to ensure we can detect changes
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
+
+            try {
+                # During execution, the callback should be set to allow all certs
+                Mock Invoke-RestMethod {
+                    # Verify callback was set during the call
+                    [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Not -BeNullOrEmpty
+                    return @{}
+                }
+
+                Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+            }
+            finally {
+                # Restore original callback
+                [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $originalCallback
+            }
+        }
+
+        It 'Restores original ServerCertificateValidationCallback after success' {
+            $originalCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Be $originalCallback
+        }
+
+        It 'Restores original ServerCertificateValidationCallback after exception' {
+            $originalCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('Connection refused')
+            }
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Be $originalCallback
+        }
+
+        It 'Restores custom ServerCertificateValidationCallback if one was set' {
+            # Set a custom callback
+            $customCallback = { param($a, $b, $c, $d) return $true }
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $customCallback
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            # Should restore the custom callback
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Be $customCallback
+
+            # Clean up
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
+        }
+    }
+
+    Context 'PowerShell 5.1 mutex behavior' -Skip:(-not $script:IsPS51) {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Successfully acquires and releases mutex under normal conditions' {
+            # This should succeed without errors
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeTrue
+        }
+
+        It 'Returns $false when mutex acquisition times out' {
+            # Create and hold the mutex to simulate timeout scenario
+            $blockingMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+            $blockingMutex.WaitOne() | Out-Null
+
+            try {
+                $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+                # Should return false when mutex cannot be acquired
+                $result | Should -BeFalse
+
+                # Should not have called Invoke-RestMethod since mutex wasn't acquired
+                Should -Invoke Invoke-RestMethod -Times 0
+            }
+            finally {
+                $blockingMutex.ReleaseMutex()
+                $blockingMutex.Dispose()
+            }
+        }
+
+        It 'Properly disposes mutex after successful operation' {
+            # Run the function
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            # Should be able to immediately acquire the mutex (meaning it was released)
+            $testMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+            $acquired = $testMutex.WaitOne(100)
+
+            try {
+                $acquired | Should -BeTrue
+            }
+            finally {
+                if ($acquired) {
+                    $testMutex.ReleaseMutex()
+                }
+                $testMutex.Dispose()
+            }
+        }
+
+        It 'Properly disposes mutex after exception' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('Connection refused')
+            }
+
+            # Run the function (will throw and catch internally)
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            # Should be able to immediately acquire the mutex (meaning it was released)
+            $testMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+            $acquired = $testMutex.WaitOne(100)
+
+            try {
+                $acquired | Should -BeTrue
+            }
+            finally {
+                if ($acquired) {
+                    $testMutex.ReleaseMutex()
+                }
+                $testMutex.Dispose()
+            }
+        }
+
+        It 'Handles mutex properly when certificate callback was already set' {
+            # Set a custom callback before the function runs
+            $customCallback = { param($a, $b, $c, $d) return $false }
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $customCallback
+
+            try {
+                Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+                # Should restore the custom callback
+                [System.Net.ServicePointManager]::ServerCertificateValidationCallback | Should -Be $customCallback
+
+                # Mutex should be released
+                $testMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+                $acquired = $testMutex.WaitOne(100)
+
+                try {
+                    $acquired | Should -BeTrue
+                }
+                finally {
+                    if ($acquired) {
+                        $testMutex.ReleaseMutex()
+                    }
+                    $testMutex.Dispose()
+                }
+            }
+            finally {
+                # Clean up
+                [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $null
+            }
+        }
+    }
+
+    Context 'Output type' {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Returns boolean type' {
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -BeOfType [bool]
+        }
+
+        It 'Returns $true on success' {
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -Be $true
+            $result | Should -BeExactly $true
+        }
+
+        It 'Returns $false on failure' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('Connection refused')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            $result | Should -Be $false
+            $result | Should -BeExactly $false
+        }
+    }
+
+    Context 'Verbose output' {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Writes verbose message about checking HTTPS' {
+            $allOutput = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400' -Verbose 4>&1
+            $verboseOutput = $allOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+
+            $verboseOutput | Should -Not -BeNullOrEmpty
+            $verboseOutput.Message | Should -Match 'Checking if HTTPS is available at https://plex.local:32400'
+        }
+
+        It 'Writes verbose message when HTTPS not available' {
+            Mock Invoke-RestMethod {
+                throw [System.Net.Http.HttpRequestException]::new('Connection refused')
+            }
+
+            $allOutput = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400' -Verbose 4>&1
+            $verboseOutput = $allOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+
+            $verboseOutput | Should -Not -BeNullOrEmpty
+            $verboseMessages = $verboseOutput.Message -join ' '
+            $verboseMessages | Should -Match 'HTTPS not available'
+        }
+
+        It 'Writes verbose message when mutex cannot be acquired' -Skip:(-not $script:IsPS51) {
+            # Create and hold the mutex
+            $blockingMutex = [System.Threading.Mutex]::new($false, 'Global\PlexAutomationToolkit_CertCallback')
+            $blockingMutex.WaitOne() | Out-Null
+
+            try {
+                $allOutput = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400' -Verbose 4>&1
+                $verboseOutput = $allOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
+
+                $verboseOutput | Should -Not -BeNullOrEmpty
+                $verboseOutput.Message | Should -Match 'Could not acquire certificate callback mutex'
+            }
+            finally {
+                $blockingMutex.ReleaseMutex()
+                $blockingMutex.Dispose()
+            }
+        }
+    }
+
+    Context 'Edge cases' {
+        It 'Handles HTTP URI with trailing slash' {
+            Mock Invoke-RestMethod { return @{} }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400/'
+
+            $result | Should -BeTrue
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -like 'https://plex.local:32400/*'
+            }
+        }
+
+        It 'Handles HTTP URI with path components' {
+            Mock Invoke-RestMethod { return @{} }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400/web'
+
+            $result | Should -BeTrue
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -like 'https://plex.local:32400/*'
+            }
+        }
+
+        It 'Handles IP address URIs' {
+            Mock Invoke-RestMethod { return @{} }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://192.168.1.100:32400'
+
+            $result | Should -BeTrue
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://192.168.1.100:32400/'
+            }
+        }
+
+        It 'Handles localhost URIs' {
+            Mock Invoke-RestMethod { return @{} }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://localhost:32400'
+
+            $result | Should -BeTrue
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://localhost:32400/'
+            }
+        }
+
+        It 'Handles exception without Response property' {
+            Mock Invoke-RestMethod {
+                throw [System.InvalidOperationException]::new('Generic error')
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            # Should not crash, should return false
+            $result | Should -BeFalse
+        }
+
+        It 'Handles exception with null Response' {
+            Mock Invoke-RestMethod {
+                $exception = [System.InvalidOperationException]::new('Error with null response')
+                $exception | Add-Member -NotePropertyName 'Response' -NotePropertyValue $null -Force
+                throw $exception
+            }
+
+            $result = Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            # Should not crash, should return false
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'Integration with Join-PatUri' {
+        BeforeEach {
+            Mock Invoke-RestMethod { return @{} }
+        }
+
+        It 'Calls Join-PatUri to construct test endpoint' {
+            Mock Join-PatUri { return 'https://plex.local:32400/' } -Verifiable
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Join-PatUri -Times 1 -ParameterFilter {
+                $BaseUri -eq 'https://plex.local:32400' -and $Endpoint -eq '/'
+            }
+        }
+
+        It 'Uses Join-PatUri result for Invoke-RestMethod' {
+            Mock Join-PatUri { return 'https://plex.local:32400/test-endpoint' }
+
+            Test-PatHttpsAvailability -HttpUri 'http://plex.local:32400'
+
+            Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter {
+                $Uri -eq 'https://plex.local:32400/test-endpoint'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `Test-PatHttpsAvailability` private helper (~80 lines) for HTTPS availability checking
- Extract `Get-PatDetectedLocalUri` private helper (~45 lines) for Plex.tv local URI detection
- Reduce `Add-PatServer` from 416 to 318 lines (~24% reduction)

## Test plan
- [x] All 1808 unit tests pass (15 skipped for PS 5.1-specific tests)
- [x] New helper functions have 91 tests (80 passing, 11 PS5.1-specific skipped)
- [x] Module loads correctly
- [x] PSScriptAnalyzer lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)