### PR TITLE
refactor: extract helper functions from Get-PatCollection

### DIFF
--- a/PlexAutomationToolkit/Private/ConvertTo-PatCollectionObject.ps1
+++ b/PlexAutomationToolkit/Private/ConvertTo-PatCollectionObject.ps1
@@ -1,0 +1,70 @@
+function ConvertTo-PatCollectionObject {
+    <#
+    .SYNOPSIS
+        Converts raw Plex API collection metadata to a typed collection object.
+
+    .DESCRIPTION
+        Internal helper function that transforms raw collection metadata from the Plex API
+        into a standardized PlexAutomationToolkit.Collection object.
+
+    .PARAMETER CollectionData
+        The raw collection metadata from the Plex API.
+
+    .PARAMETER LibraryId
+        The library section ID this collection belongs to.
+
+    .PARAMETER LibraryName
+        The name of the library this collection belongs to.
+
+    .PARAMETER ServerUri
+        The Plex server URI.
+
+    .OUTPUTS
+        PlexAutomationToolkit.Collection
+        A typed collection object with standardized properties.
+
+    .EXAMPLE
+        $collectionObj = ConvertTo-PatCollectionObject -CollectionData $apiResult -LibraryId 1 -LibraryName 'Movies' -ServerUri 'http://plex:32400'
+
+        Converts raw API data to a collection object.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSObject]
+        $CollectionData,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $LibraryId,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $LibraryName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServerUri
+    )
+
+    process {
+        [PSCustomObject]@{
+            PSTypeName   = 'PlexAutomationToolkit.Collection'
+            CollectionId = [int]$CollectionData.ratingKey
+            Title        = $CollectionData.title
+            LibraryId    = $LibraryId
+            LibraryName  = $LibraryName
+            ItemCount    = [int]$CollectionData.childCount
+            Thumb        = $CollectionData.thumb
+            AddedAt      = if ($CollectionData.addedAt) {
+                [DateTimeOffset]::FromUnixTimeSeconds([long]$CollectionData.addedAt).LocalDateTime
+            } else { $null }
+            UpdatedAt    = if ($CollectionData.updatedAt) {
+                [DateTimeOffset]::FromUnixTimeSeconds([long]$CollectionData.updatedAt).LocalDateTime
+            } else { $null }
+            ServerUri    = $ServerUri
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-PatCollectionItem.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatCollectionItem.ps1
@@ -1,0 +1,87 @@
+function Get-PatCollectionItem {
+    <#
+    .SYNOPSIS
+        Retrieves items from a Plex collection.
+
+    .DESCRIPTION
+        Internal helper function that fetches the items belonging to a collection
+        and transforms them into typed CollectionItem objects.
+
+    .PARAMETER CollectionId
+        The unique identifier of the collection.
+
+    .PARAMETER CollectionTitle
+        The title of the collection (used for warning messages).
+
+    .PARAMETER ServerUri
+        The base URI of the Plex server.
+
+    .PARAMETER Headers
+        The authentication headers for API requests.
+
+    .OUTPUTS
+        PlexAutomationToolkit.CollectionItem[]
+        An array of collection item objects.
+
+    .EXAMPLE
+        $items = Get-PatCollectionItem -CollectionId 12345 -CollectionTitle 'Marvel' -ServerUri 'http://plex:32400' -Headers $headers
+
+        Retrieves all items from the specified collection.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [int]
+        $CollectionId,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $CollectionTitle,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServerUri,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Headers
+    )
+
+    process {
+        $itemsEndpoint = "/library/collections/$CollectionId/children"
+        $itemsUri = Join-PatUri -BaseUri $ServerUri -Endpoint $itemsEndpoint
+
+        try {
+            $itemsResult = Invoke-PatApi -Uri $itemsUri -Headers $Headers -ErrorAction 'Stop'
+
+            if (-not $itemsResult -or -not $itemsResult.Metadata) {
+                return @()
+            }
+
+            $items = foreach ($item in $itemsResult.Metadata) {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PlexAutomationToolkit.CollectionItem'
+                    RatingKey    = [int]$item.ratingKey
+                    Title        = $item.title
+                    Type         = $item.type
+                    Year         = if ($item.year) { [int]$item.year } else { $null }
+                    Thumb        = $item.thumb
+                    AddedAt      = if ($item.addedAt) {
+                        [DateTimeOffset]::FromUnixTimeSeconds([long]$item.addedAt).LocalDateTime
+                    } else { $null }
+                    CollectionId = $CollectionId
+                    ServerUri    = $ServerUri
+                }
+            }
+
+            return $items
+        }
+        catch {
+            $title = if ($CollectionTitle) { $CollectionTitle } else { "ID $CollectionId" }
+            Write-Warning "Failed to retrieve items for collection '$title': $($_.Exception.Message)"
+            return @()
+        }
+    }
+}

--- a/tests/Unit/Private/ConvertTo-PatCollectionObject.tests.ps1
+++ b/tests/Unit/Private/ConvertTo-PatCollectionObject.tests.ps1
@@ -1,0 +1,478 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'ConvertTo-PatCollectionObject' {
+    Context 'Parameter validation' {
+        It 'Should throw when CollectionData is null' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    ConvertTo-PatCollectionObject -CollectionData $null -LibraryId 1 -ServerUri 'http://localhost:32400'
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when LibraryId is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $data = @{ ratingKey = 123; title = 'Test' }
+                    ConvertTo-PatCollectionObject -CollectionData $data -ServerUri 'http://localhost:32400'
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when ServerUri is null' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $data = @{ ratingKey = 123; title = 'Test' }
+                    ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri $null
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when ServerUri is empty' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $data = @{ ratingKey = 123; title = 'Test' }
+                    ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri ''
+                }
+            } | Should -Throw
+        }
+
+        It 'Should accept null LibraryName' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $data = @{ ratingKey = 123; title = 'Test'; childCount = 5 }
+                    ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -LibraryName $null -ServerUri 'http://localhost:32400'
+                }
+            } | Should -Not -Throw
+        }
+    }
+
+    Context 'Property mapping from API data' {
+        It 'Should map ratingKey to CollectionId' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 12345
+                    title      = 'Test Collection'
+                    childCount = 10
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.CollectionId | Should -Be 12345
+            $result.CollectionId | Should -BeOfType [int]
+        }
+
+        It 'Should map title to Title' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Marvel Collection'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.Title | Should -Be 'Marvel Collection'
+        }
+
+        It 'Should map childCount to ItemCount' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 42
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.ItemCount | Should -Be 42
+            $result.ItemCount | Should -BeOfType [int]
+        }
+
+        It 'Should preserve LibraryId parameter' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 7 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.LibraryId | Should -Be 7
+        }
+
+        It 'Should preserve LibraryName parameter when provided' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -LibraryName 'Movies' -ServerUri 'http://localhost:32400'
+            }
+
+            $result.LibraryName | Should -Be 'Movies'
+        }
+
+        It 'Should set LibraryName to null when not provided' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.LibraryName | Should -BeNullOrEmpty
+        }
+
+        It 'Should map thumb to Thumb' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    thumb      = '/library/metadata/123/thumb/1234567890'
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.Thumb | Should -Be '/library/metadata/123/thumb/1234567890'
+        }
+
+        It 'Should preserve ServerUri parameter' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'https://plex.example.com:32400'
+            }
+
+            $result.ServerUri | Should -Be 'https://plex.example.com:32400'
+        }
+    }
+
+    Context 'DateTime conversion from Unix timestamps' {
+        It 'Should convert addedAt Unix timestamp to DateTime' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    addedAt    = 1609459200  # 2021-01-01 00:00:00 UTC
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.AddedAt | Should -BeOfType [DateTime]
+            $result.AddedAt | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should convert updatedAt Unix timestamp to DateTime' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    updatedAt  = 1609545600  # 2021-01-02 00:00:00 UTC
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.UpdatedAt | Should -BeOfType [DateTime]
+            $result.UpdatedAt | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should convert both addedAt and updatedAt timestamps' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    addedAt    = 1609459200
+                    updatedAt  = 1609545600
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.AddedAt | Should -BeOfType [DateTime]
+            $result.UpdatedAt | Should -BeOfType [DateTime]
+            $result.UpdatedAt | Should -BeGreaterThan $result.AddedAt
+        }
+
+        It 'Should use LocalDateTime for converted timestamps' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    addedAt    = 1609459200
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            # Verify it's a DateTime (not DateTimeOffset) and represents local time
+            $result.AddedAt.GetType().Name | Should -Be 'DateTime'
+        }
+    }
+
+    Context 'Handling null/missing optional fields' {
+        It 'Should set AddedAt to null when addedAt is missing' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.AddedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should set AddedAt to null when addedAt is null' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    addedAt    = $null
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.AddedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should set AddedAt to null when addedAt is 0' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    addedAt    = 0
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.AddedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should set UpdatedAt to null when updatedAt is missing' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.UpdatedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should set UpdatedAt to null when updatedAt is null' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    updatedAt  = $null
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.UpdatedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should set UpdatedAt to null when updatedAt is 0' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    updatedAt  = 0
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.UpdatedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should handle missing thumb property' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.Thumb | Should -BeNullOrEmpty
+        }
+
+        It 'Should handle null thumb property' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                    thumb      = $null
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.Thumb | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'PSTypeName is set correctly' {
+        It 'Should set PSTypeName to PlexAutomationToolkit.Collection' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test Collection'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.Collection'
+        }
+
+        It 'Should return PSCustomObject type' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result | Should -BeOfType [PSCustomObject]
+        }
+    }
+
+    Context 'Complete collection object with all properties' {
+        It 'Should create complete collection object with all properties' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 98765
+                    title      = 'Star Wars Collection'
+                    childCount = 11
+                    thumb      = '/library/metadata/98765/thumb/1234567890'
+                    addedAt    = 1609459200  # 2021-01-01 00:00:00 UTC
+                    updatedAt  = 1640995200  # 2022-01-01 00:00:00 UTC
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 3 -LibraryName 'Movies' -ServerUri 'https://plex.example.com:32400'
+            }
+
+            $result.PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.Collection'
+            $result.CollectionId | Should -Be 98765
+            $result.Title | Should -Be 'Star Wars Collection'
+            $result.LibraryId | Should -Be 3
+            $result.LibraryName | Should -Be 'Movies'
+            $result.ItemCount | Should -Be 11
+            $result.Thumb | Should -Be '/library/metadata/98765/thumb/1234567890'
+            $result.AddedAt | Should -BeOfType [DateTime]
+            $result.UpdatedAt | Should -BeOfType [DateTime]
+            $result.ServerUri | Should -Be 'https://plex.example.com:32400'
+        }
+    }
+
+    Context 'Type casting behavior' {
+        It 'Should cast ratingKey to int from string' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = '12345'
+                    title      = 'Test'
+                    childCount = 5
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.CollectionId | Should -Be 12345
+            $result.CollectionId | Should -BeOfType [int]
+        }
+
+        It 'Should cast childCount to int from string' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Test'
+                    childCount = '42'
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.ItemCount | Should -Be 42
+            $result.ItemCount | Should -BeOfType [int]
+        }
+
+        It 'Should handle zero childCount' {
+            $result = InModuleScope PlexAutomationToolkit {
+                $data = [PSCustomObject]@{
+                    ratingKey  = 123
+                    title      = 'Empty Collection'
+                    childCount = 0
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -ServerUri 'http://localhost:32400'
+            }
+
+            $result.ItemCount | Should -Be 0
+            $result.ItemCount | Should -BeOfType [int]
+        }
+    }
+
+    Context 'Real-world API response simulation' {
+        It 'Should convert typical Plex collection API response' {
+            $result = InModuleScope PlexAutomationToolkit {
+                # Simulates actual Plex API response structure
+                $data = [PSCustomObject]@{
+                    ratingKey         = 234567
+                    key               = '/library/collections/234567/children'
+                    guid              = 'collection://234567'
+                    type              = 'collection'
+                    title             = 'MCU Timeline Order'
+                    subtype           = 'movie'
+                    summary           = 'Marvel movies in chronological order'
+                    index             = 1
+                    thumb             = '/library/metadata/234567/thumb/1640995200'
+                    addedAt           = 1577836800  # 2020-01-01 00:00:00 UTC
+                    updatedAt         = 1640995200  # 2022-01-01 00:00:00 UTC
+                    childCount        = 30
+                    maxYear           = 2023
+                    minYear           = 2008
+                    contentRating     = 'PG-13'
+                    ratingCount       = 150
+                }
+                ConvertTo-PatCollectionObject -CollectionData $data -LibraryId 1 -LibraryName 'Movies' -ServerUri 'http://localhost:32400'
+            }
+
+            # Verify all mapped properties
+            $result.CollectionId | Should -Be 234567
+            $result.Title | Should -Be 'MCU Timeline Order'
+            $result.LibraryId | Should -Be 1
+            $result.LibraryName | Should -Be 'Movies'
+            $result.ItemCount | Should -Be 30
+            $result.Thumb | Should -Be '/library/metadata/234567/thumb/1640995200'
+            $result.AddedAt | Should -BeOfType [DateTime]
+            $result.UpdatedAt | Should -BeOfType [DateTime]
+            $result.ServerUri | Should -Be 'http://localhost:32400'
+            $result.PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.Collection'
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatCollectionItem.tests.ps1
+++ b/tests/Unit/Private/Get-PatCollectionItem.tests.ps1
@@ -1,0 +1,743 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Get-PatCollectionItem' {
+    BeforeAll {
+        # Set up common test data
+        $script:testServerUri = 'http://localhost:32400'
+        $script:testHeaders = @{
+            'X-Plex-Token' = 'test-token-123'
+            'Accept'       = 'application/json'
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Should throw when CollectionId is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                    param($uri, $headers)
+                    Get-PatCollectionItem -ServerUri $uri -Headers $headers
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when ServerUri is null' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testHeaders {
+                    param($headers)
+                    Get-PatCollectionItem -CollectionId 123 -ServerUri $null -Headers $headers
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when ServerUri is empty' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testHeaders {
+                    param($headers)
+                    Get-PatCollectionItem -CollectionId 123 -ServerUri '' -Headers $headers
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when Headers is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri {
+                    param($uri)
+                    Get-PatCollectionItem -CollectionId 123 -ServerUri $uri
+                }
+            } | Should -Throw
+        }
+
+        It 'Should accept null CollectionTitle' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                    param($uri, $headers)
+                    Mock Invoke-PatApi { return @{ Metadata = @() } }
+                    Get-PatCollectionItem -CollectionId 123 -CollectionTitle $null -ServerUri $uri -Headers $headers
+                }
+            } | Should -Not -Throw
+        }
+
+        It 'Should not require CollectionTitle parameter' {
+            {
+                InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                    param($uri, $headers)
+                    Mock Invoke-PatApi { return @{ Metadata = @() } }
+                    Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+                }
+            } | Should -Not -Throw
+        }
+    }
+
+    Context 'API endpoint construction' {
+        It 'Should construct correct API endpoint with collection ID' {
+            InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return $BaseUri + $Endpoint } -Verifiable
+                Mock Invoke-PatApi { return @{ Metadata = @() } }
+
+                Get-PatCollectionItem -CollectionId 12345 -ServerUri $uri -Headers $headers
+
+                Should -Invoke Join-PatUri -Times 1 -ParameterFilter {
+                    $Endpoint -eq '/library/collections/12345/children'
+                }
+            }
+        }
+
+        It 'Should pass ServerUri to Join-PatUri' {
+            InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://localhost:32400/library/collections/123/children' } -Verifiable
+                Mock Invoke-PatApi { return @{ Metadata = @() } }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+
+                Should -Invoke Join-PatUri -Times 1 -ParameterFilter {
+                    $BaseUri -eq 'http://localhost:32400'
+                }
+            }
+        }
+
+        It 'Should call Invoke-PatApi with constructed URI' {
+            InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                $expectedUri = 'http://localhost:32400/library/collections/123/children'
+                Mock Join-PatUri { return $expectedUri }
+                Mock Invoke-PatApi { return @{ Metadata = @() } } -Verifiable
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+
+                Should -Invoke Invoke-PatApi -Times 1 -ParameterFilter {
+                    $Uri -eq $expectedUri
+                }
+            }
+        }
+
+        It 'Should call Invoke-PatApi with provided headers' {
+            InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://localhost:32400/library/collections/123/children' }
+                Mock Invoke-PatApi { return @{ Metadata = @() } } -Verifiable
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+
+                Should -Invoke Invoke-PatApi -Times 1 -ParameterFilter {
+                    $Headers['X-Plex-Token'] -eq 'test-token-123'
+                }
+            }
+        }
+
+        It 'Should call Invoke-PatApi with ErrorAction Stop' {
+            InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://localhost:32400/library/collections/123/children' }
+                Mock Invoke-PatApi { return @{ Metadata = @() } } -Verifiable
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+
+                Should -Invoke Invoke-PatApi -Times 1 -ParameterFilter {
+                    $ErrorAction -eq 'Stop'
+                }
+            }
+        }
+    }
+
+    Context 'Successful item retrieval and transformation' {
+        It 'Should return array of collection items' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Movie 1'
+                                type      = 'movie'
+                                year      = 2020
+                                thumb     = '/thumb1.jpg'
+                                addedAt   = 1609459200
+                            }
+                            [PSCustomObject]@{
+                                ratingKey = 222
+                                title     = 'Movie 2'
+                                type      = 'movie'
+                                year      = 2021
+                                thumb     = '/thumb2.jpg'
+                                addedAt   = 1640995200
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -HaveCount 2
+        }
+
+        It 'Should transform items with correct properties' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 12345
+                                title     = 'Avengers: Endgame'
+                                type      = 'movie'
+                                year      = 2019
+                                thumb     = '/library/metadata/12345/thumb/1234567890'
+                                addedAt   = 1609459200
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 999 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].RatingKey | Should -Be 12345
+            $result[0].RatingKey | Should -BeOfType [int]
+            $result[0].Title | Should -Be 'Avengers: Endgame'
+            $result[0].Type | Should -Be 'movie'
+            $result[0].Year | Should -Be 2019
+            $result[0].Thumb | Should -Be '/library/metadata/12345/thumb/1234567890'
+            $result[0].AddedAt | Should -BeOfType [DateTime]
+            $result[0].CollectionId | Should -Be 999
+            $result[0].ServerUri | Should -Be $script:testServerUri
+        }
+
+        It 'Should set PSTypeName to PlexAutomationToolkit.CollectionItem' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.CollectionItem'
+        }
+
+        It 'Should convert addedAt Unix timestamp to DateTime' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                                addedAt   = 1609459200  # 2021-01-01 00:00:00 UTC
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].AddedAt | Should -BeOfType [DateTime]
+            $result[0].AddedAt | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should handle null year property' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                                year      = $null
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].Year | Should -BeNullOrEmpty
+        }
+
+        It 'Should handle missing year property' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].Year | Should -BeNullOrEmpty
+        }
+
+        It 'Should handle null addedAt property' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                                addedAt   = $null
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].AddedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should handle zero addedAt property' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Test'
+                                type      = 'movie'
+                                addedAt   = 0
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].AddedAt | Should -BeNullOrEmpty
+        }
+
+        It 'Should preserve CollectionId in each item' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Movie 1'
+                                type      = 'movie'
+                            }
+                            [PSCustomObject]@{
+                                ratingKey = 222
+                                title     = 'Movie 2'
+                                type      = 'movie'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 54321 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].CollectionId | Should -Be 54321
+            $result[1].CollectionId | Should -Be 54321
+        }
+
+        It 'Should preserve ServerUri in each item' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testHeaders {
+                param($headers)
+                Mock Join-PatUri { return 'https://plex.example.com:32400/library/collections/123/children' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'Movie 1'
+                                type      = 'movie'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri 'https://plex.example.com:32400' -Headers $headers
+            }
+
+            $result[0].ServerUri | Should -Be 'https://plex.example.com:32400'
+        }
+    }
+
+    Context 'Empty results handling' {
+        It 'Should return empty array when result is null' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { return $null }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+
+        It 'Should return empty array when Metadata is null' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = $null
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+
+        It 'Should return empty array when Metadata is empty array' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @()
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+
+        It 'Should return empty array when result has no Metadata property' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        size = 0
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+    }
+
+    Context 'Error handling with warning output' {
+        It 'Should catch errors and return empty array' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw 'API connection failed' }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers 3>$null
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+
+        It 'Should output warning when error occurs' {
+            $warnings = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw '404 Not Found' }
+
+                $warningList = @()
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers -WarningVariable warningList 3>$null
+                return $warningList
+            }
+
+            $warnings | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should include collection ID in warning when CollectionTitle not provided' {
+            $warnings = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw 'Connection timeout' }
+
+                $warningList = @()
+                Get-PatCollectionItem -CollectionId 12345 -ServerUri $uri -Headers $headers -WarningVariable warningList 3>$null
+                return $warningList
+            }
+
+            $warnings | Should -Match 'ID 12345'
+        }
+
+        It 'Should include CollectionTitle in warning when provided' {
+            $warnings = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw 'Server error' }
+
+                $warningList = @()
+                Get-PatCollectionItem -CollectionId 123 -CollectionTitle 'Marvel Movies' -ServerUri $uri -Headers $headers -WarningVariable warningList 3>$null
+                return $warningList
+            }
+
+            $warnings | Should -Match 'Marvel Movies'
+            $warnings | Should -Not -Match 'ID 123'
+        }
+
+        It 'Should include error message in warning' {
+            $warnings = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw 'Authentication failed: Invalid token' }
+
+                $warningList = @()
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers -WarningVariable warningList 3>$null
+                return $warningList
+            }
+
+            $warnings | Should -Match 'Invalid token'
+        }
+
+        It 'Should handle HTTP 404 error gracefully' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw '404 Not Found' }
+
+                Get-PatCollectionItem -CollectionId 999 -ServerUri $uri -Headers $headers 3>$null
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+
+        It 'Should handle network timeout gracefully' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi { throw 'The operation has timed out' }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers 3>$null
+            }
+
+            $result | Should -BeNullOrEmpty
+            @($result).Count | Should -Be 0
+        }
+    }
+
+    Context 'Real-world API response simulation' {
+        It 'Should handle typical Plex collection items response' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey           = 45678
+                                key                 = '/library/metadata/45678'
+                                guid                = 'plex://movie/5d7768ba96b655001fdc0408'
+                                studio              = 'Marvel Studios'
+                                type                = 'movie'
+                                title               = 'Iron Man'
+                                contentRating       = 'PG-13'
+                                summary             = 'Tony Stark builds an armored suit...'
+                                rating              = 7.9
+                                year                = 2008
+                                thumb               = '/library/metadata/45678/thumb/1234567890'
+                                art                 = '/library/metadata/45678/art/1234567890'
+                                duration            = 7560000
+                                originallyAvailableAt = '2008-05-02'
+                                addedAt             = 1577836800
+                                updatedAt           = 1609459200
+                            }
+                            [PSCustomObject]@{
+                                ratingKey           = 45679
+                                key                 = '/library/metadata/45679'
+                                guid                = 'plex://movie/5d7768c196b655001fdc044a'
+                                studio              = 'Marvel Studios'
+                                type                = 'movie'
+                                title               = 'The Incredible Hulk'
+                                contentRating       = 'PG-13'
+                                summary             = 'Bruce Banner seeks a cure...'
+                                rating              = 6.7
+                                year                = 2008
+                                thumb               = '/library/metadata/45679/thumb/1234567891'
+                                art                 = '/library/metadata/45679/art/1234567891'
+                                duration            = 6720000
+                                originallyAvailableAt = '2008-06-13'
+                                addedAt             = 1577836801
+                                updatedAt           = 1609459201
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 12345 -CollectionTitle 'MCU Phase 1' -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -HaveCount 2
+            $result[0].RatingKey | Should -Be 45678
+            $result[0].Title | Should -Be 'Iron Man'
+            $result[0].Type | Should -Be 'movie'
+            $result[0].Year | Should -Be 2008
+            $result[0].AddedAt | Should -BeOfType [DateTime]
+            $result[0].CollectionId | Should -Be 12345
+            $result[1].Title | Should -Be 'The Incredible Hulk'
+        }
+
+        It 'Should handle TV show items in collection' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 77777
+                                title     = 'Breaking Bad'
+                                type      = 'show'
+                                year      = 2008
+                                thumb     = '/library/metadata/77777/thumb/1234567890'
+                                addedAt   = 1609459200
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 999 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].Type | Should -Be 'show'
+            $result[0].PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.CollectionItem'
+        }
+
+        It 'Should handle mixed media types in collection' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 111
+                                title     = 'A Movie'
+                                type      = 'movie'
+                                year      = 2020
+                            }
+                            [PSCustomObject]@{
+                                ratingKey = 222
+                                title     = 'A TV Show'
+                                type      = 'show'
+                                year      = 2021
+                            }
+                            [PSCustomObject]@{
+                                ratingKey = 333
+                                title     = 'A Season'
+                                type      = 'season'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 456 -ServerUri $uri -Headers $headers
+            }
+
+            $result | Should -HaveCount 3
+            $result[0].Type | Should -Be 'movie'
+            $result[1].Type | Should -Be 'show'
+            $result[2].Type | Should -Be 'season'
+        }
+    }
+
+    Context 'Type casting behavior' {
+        It 'Should cast ratingKey to int from string' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = '12345'
+                                title     = 'Test'
+                                type      = 'movie'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].RatingKey | Should -Be 12345
+            $result[0].RatingKey | Should -BeOfType [int]
+        }
+
+        It 'Should cast year to int from string' {
+            $result = InModuleScope PlexAutomationToolkit -ArgumentList $script:testServerUri, $script:testHeaders {
+                param($uri, $headers)
+                Mock Join-PatUri { return 'http://test/uri' }
+                Mock Invoke-PatApi {
+                    return [PSCustomObject]@{
+                        Metadata = @(
+                            [PSCustomObject]@{
+                                ratingKey = 123
+                                title     = 'Test'
+                                type      = 'movie'
+                                year      = '2020'
+                            }
+                        )
+                    }
+                }
+
+                Get-PatCollectionItem -CollectionId 123 -ServerUri $uri -Headers $headers
+            }
+
+            $result[0].Year | Should -Be 2020
+            $result[0].Year | Should -BeOfType [int]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ConvertTo-PatCollectionObject` private helper for API metadata transformation
- Extract `Get-PatCollectionItem` private helper for collection item retrieval
- Replace 3 instances of manual server parameter building with `Build-PatServerSplat`
- Reduce `Get-PatCollection` from 381 to 288 lines (~24% reduction)

## Test plan
- [x] All 1877 unit tests pass (15 skipped for PS 5.1-specific tests)
- [x] New helper functions have 69 tests (all passing)
- [x] Module loads correctly
- [x] PSScriptAnalyzer lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)