### PR TITLE
refactor: extract helper functions from Compare-PatWatchStatus

### DIFF
--- a/PlexAutomationToolkit/Private/ConvertTo-PatWatchStatusDiff.ps1
+++ b/PlexAutomationToolkit/Private/ConvertTo-PatWatchStatusDiff.ps1
@@ -1,0 +1,138 @@
+function ConvertTo-PatWatchStatusDiff {
+    <#
+    .SYNOPSIS
+        Creates a watch status difference object.
+
+    .DESCRIPTION
+        Internal helper function that creates a standardized WatchStatusDiff object
+        representing the difference in watch status between source and target servers.
+
+    .PARAMETER Type
+        The type of media item: 'movie' or 'episode'.
+
+    .PARAMETER Title
+        The title of the item.
+
+    .PARAMETER Year
+        The release year (for movies, null for episodes).
+
+    .PARAMETER ShowName
+        The TV show name (for episodes, null for movies).
+
+    .PARAMETER Season
+        The season number (for episodes, null for movies).
+
+    .PARAMETER Episode
+        The episode number (for episodes, null for movies).
+
+    .PARAMETER SourceWatched
+        Whether the item is watched on the source server.
+
+    .PARAMETER TargetWatched
+        Whether the item is watched on the target server.
+
+    .PARAMETER SourceViewCount
+        The view count on the source server.
+
+    .PARAMETER TargetViewCount
+        The view count on the target server.
+
+    .PARAMETER SourceRatingKey
+        The rating key on the source server.
+
+    .PARAMETER TargetRatingKey
+        The rating key on the target server.
+
+    .OUTPUTS
+        PlexAutomationToolkit.WatchStatusDiff
+        A typed object representing the watch status difference.
+
+    .EXAMPLE
+        ConvertTo-PatWatchStatusDiff -Type 'movie' -Title 'The Matrix' -Year 1999 `
+            -SourceWatched $true -TargetWatched $false `
+            -SourceViewCount 2 -TargetViewCount 0 `
+            -SourceRatingKey 123 -TargetRatingKey 456
+
+        Creates a diff object for a movie that is watched on source but not target.
+
+    .EXAMPLE
+        ConvertTo-PatWatchStatusDiff -Type 'episode' -Title 'Pilot' `
+            -ShowName 'Breaking Bad' -Season 1 -Episode 1 `
+            -SourceWatched $false -TargetWatched $true `
+            -SourceViewCount 0 -TargetViewCount 1 `
+            -SourceRatingKey 789 -TargetRatingKey 101
+
+        Creates a diff object for an episode that is watched on target but not source.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('movie', 'episode')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Title,
+
+        [Parameter(Mandatory = $false)]
+        [Nullable[int]]
+        $Year,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ShowName,
+
+        [Parameter(Mandatory = $false)]
+        [Nullable[int]]
+        $Season,
+
+        [Parameter(Mandatory = $false)]
+        [Nullable[int]]
+        $Episode,
+
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $SourceWatched,
+
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $TargetWatched,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $SourceViewCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $TargetViewCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $SourceRatingKey,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $TargetRatingKey
+    )
+
+    process {
+        [PSCustomObject]@{
+            PSTypeName      = 'PlexAutomationToolkit.WatchStatusDiff'
+            Title           = $Title
+            Type            = $Type
+            Year            = $Year
+            ShowName        = $ShowName
+            Season          = $Season
+            Episode         = $Episode
+            SourceWatched   = $SourceWatched
+            TargetWatched   = $TargetWatched
+            SourceViewCount = $SourceViewCount
+            TargetViewCount = $TargetViewCount
+            SourceRatingKey = $SourceRatingKey
+            TargetRatingKey = $TargetRatingKey
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-PatShowEpisodes.ps1
+++ b/PlexAutomationToolkit/Private/Get-PatShowEpisodes.ps1
@@ -1,0 +1,58 @@
+function Get-PatShowEpisodes {
+    <#
+    .SYNOPSIS
+        Retrieves all episodes for a TV show from a Plex server.
+
+    .DESCRIPTION
+        Internal helper function that fetches all episodes (leaves) for a given TV show
+        using the Plex API's allLeaves endpoint. Returns the raw episode metadata from
+        the API response.
+
+    .PARAMETER Server
+        The server configuration object containing uri and authentication details.
+
+    .PARAMETER ShowRatingKey
+        The rating key (unique identifier) of the TV show.
+
+    .OUTPUTS
+        PSObject[]
+        An array of episode metadata objects from the Plex API, or an empty array if
+        no episodes are found or an error occurs.
+
+    .EXAMPLE
+        $episodes = Get-PatShowEpisodes -Server $serverConfig -ShowRatingKey 12345
+
+        Retrieves all episodes for the show with rating key 12345.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSObject[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [PSObject]
+        $Server,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $ShowRatingKey
+    )
+
+    process {
+        $episodesUri = Join-PatUri -BaseUri $Server.uri -Endpoint "/library/metadata/$ShowRatingKey/allLeaves"
+        $headers = Get-PatAuthenticationHeader -Server $Server
+
+        try {
+            $episodesResult = Invoke-PatApi -Uri $episodesUri -Headers $headers -ErrorAction Stop
+
+            if ($episodesResult -and $episodesResult.Metadata) {
+                return $episodesResult.Metadata
+            }
+
+            return @()
+        }
+        catch {
+            Write-Verbose "Failed to retrieve episodes for show $ShowRatingKey : $($_.Exception.Message)"
+            return @()
+        }
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-WatchStatusMatchKey.ps1
+++ b/PlexAutomationToolkit/Private/Get-WatchStatusMatchKey.ps1
@@ -1,0 +1,95 @@
+function Get-WatchStatusMatchKey {
+    <#
+    .SYNOPSIS
+        Generates a normalized match key for comparing watch status across servers.
+
+    .DESCRIPTION
+        Internal helper function that creates a consistent key for matching media items
+        between different Plex servers. Normalizes titles by converting to lowercase,
+        trimming whitespace, and removing special characters to improve matching accuracy.
+
+    .PARAMETER Type
+        The type of media item: 'movie' or 'episode'.
+
+    .PARAMETER Title
+        The title of the item (used for movies).
+
+    .PARAMETER Year
+        The release year (used for movies).
+
+    .PARAMETER ShowName
+        The name of the TV show (used for episodes).
+
+    .PARAMETER Season
+        The season number (used for episodes).
+
+    .PARAMETER Episode
+        The episode number (used for episodes).
+
+    .OUTPUTS
+        System.String
+        A normalized match key in the format:
+        - Movies: "movie|<normalized_title>|<year>"
+        - Episodes: "episode|<normalized_show>|S<season>E<episode>"
+        - Unknown: "unknown|<normalized_title>"
+
+    .EXAMPLE
+        Get-WatchStatusMatchKey -Type 'movie' -Title 'The Matrix' -Year 1999
+
+        Returns: "movie|the matrix|1999"
+
+    .EXAMPLE
+        Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 1
+
+        Returns: "episode|breaking bad|S1E1"
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('movie', 'episode')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Title,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $Year,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ShowName,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $Season,
+
+        [Parameter(Mandatory = $false)]
+        [int]
+        $Episode
+    )
+
+    process {
+        # Normalize title for comparison
+        $normalizedTitle = if ($Title) {
+            $Title.ToLowerInvariant().Trim() -replace '[^\w\s]', ''
+        }
+        else { '' }
+
+        if ($Type -eq 'movie') {
+            return "movie|$normalizedTitle|$Year"
+        }
+        elseif ($Type -eq 'episode') {
+            $normalizedShow = if ($ShowName) {
+                $ShowName.ToLowerInvariant().Trim() -replace '[^\w\s]', ''
+            }
+            else { '' }
+            return "episode|$normalizedShow|S${Season}E${Episode}"
+        }
+
+        return "unknown|$normalizedTitle"
+    }
+}

--- a/PlexAutomationToolkit/Private/Get-WatchStatusMatchKey.ps1
+++ b/PlexAutomationToolkit/Private/Get-WatchStatusMatchKey.ps1
@@ -31,7 +31,6 @@ function Get-WatchStatusMatchKey {
         A normalized match key in the format:
         - Movies: "movie|<normalized_title>|<year>"
         - Episodes: "episode|<normalized_show>|S<season>E<episode>"
-        - Unknown: "unknown|<normalized_title>"
 
     .EXAMPLE
         Get-WatchStatusMatchKey -Type 'movie' -Title 'The Matrix' -Year 1999
@@ -82,14 +81,13 @@ function Get-WatchStatusMatchKey {
         if ($Type -eq 'movie') {
             return "movie|$normalizedTitle|$Year"
         }
-        elseif ($Type -eq 'episode') {
+        else {
+            # Type is 'episode' (guaranteed by ValidateSet)
             $normalizedShow = if ($ShowName) {
                 $ShowName.ToLowerInvariant().Trim() -replace '[^\w\s]', ''
             }
             else { '' }
             return "episode|$normalizedShow|S${Season}E${Episode}"
         }
-
-        return "unknown|$normalizedTitle"
     }
 }

--- a/tests/Unit/Private/ConvertTo-PatWatchStatusDiff.tests.ps1
+++ b/tests/Unit/Private/ConvertTo-PatWatchStatusDiff.tests.ps1
@@ -1,0 +1,372 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'ConvertTo-PatWatchStatusDiff' {
+    Context 'Parameter Validation' {
+        It 'Should throw when Type is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    ConvertTo-PatWatchStatusDiff -Title 'Test' `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw for invalid Type value' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    ConvertTo-PatWatchStatusDiff -Type 'invalid' -Title 'Test' `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when Title is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw for empty Title' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    ConvertTo-PatWatchStatusDiff -Type 'movie' -Title '' `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                }
+            } | Should -Throw
+        }
+
+        It 'Should accept movie as Type' {
+            InModuleScope PlexAutomationToolkit {
+                {
+                    ConvertTo-PatWatchStatusDiff -Type 'movie' -Title 'Test' -Year 2020 `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                } | Should -Not -Throw
+            }
+        }
+
+        It 'Should accept episode as Type' {
+            InModuleScope PlexAutomationToolkit {
+                {
+                    ConvertTo-PatWatchStatusDiff -Type 'episode' -Title 'Pilot' `
+                        -ShowName 'Test Show' -Season 1 -Episode 1 `
+                        -SourceWatched $true -TargetWatched $false `
+                        -SourceViewCount 1 -TargetViewCount 0 `
+                        -SourceRatingKey 123 -TargetRatingKey 456
+                } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'Movie Diff Creation' {
+        It 'Should create correct movie diff object' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'The Matrix' -Year 1999 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 2 -TargetViewCount 0 `
+                    -SourceRatingKey 123 -TargetRatingKey 456
+
+                $result.Title | Should -Be 'The Matrix'
+                $result.Type | Should -Be 'movie'
+                $result.Year | Should -Be 1999
+                $result.ShowName | Should -BeNullOrEmpty
+                $result.Season | Should -BeNullOrEmpty
+                $result.Episode | Should -BeNullOrEmpty
+                $result.SourceWatched | Should -Be $true
+                $result.TargetWatched | Should -Be $false
+                $result.SourceViewCount | Should -Be 2
+                $result.TargetViewCount | Should -Be 0
+                $result.SourceRatingKey | Should -Be 123
+                $result.TargetRatingKey | Should -Be 456
+            }
+        }
+
+        It 'Should set correct PSTypeName for movie' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test Movie' -Year 2020 `
+                    -SourceWatched $false -TargetWatched $true `
+                    -SourceViewCount 0 -TargetViewCount 1 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.WatchStatusDiff'
+            }
+        }
+
+        It 'Should handle movie without year' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Unknown Year Movie' `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 111 -TargetRatingKey 222
+
+                $result.Year | Should -BeNullOrEmpty
+                $result.Title | Should -Be 'Unknown Year Movie'
+            }
+        }
+
+        It 'Should handle movie with year 0' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test' -Year 0 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.Year | Should -Be 0
+            }
+        }
+    }
+
+    Context 'Episode Diff Creation' {
+        It 'Should create correct episode diff object' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'episode' `
+                    -Title 'Pilot' -ShowName 'Breaking Bad' -Season 1 -Episode 1 `
+                    -SourceWatched $false -TargetWatched $true `
+                    -SourceViewCount 0 -TargetViewCount 1 `
+                    -SourceRatingKey 789 -TargetRatingKey 101
+
+                $result.Title | Should -Be 'Pilot'
+                $result.Type | Should -Be 'episode'
+                $result.Year | Should -BeNullOrEmpty
+                $result.ShowName | Should -Be 'Breaking Bad'
+                $result.Season | Should -Be 1
+                $result.Episode | Should -Be 1
+                $result.SourceWatched | Should -Be $false
+                $result.TargetWatched | Should -Be $true
+                $result.SourceViewCount | Should -Be 0
+                $result.TargetViewCount | Should -Be 1
+                $result.SourceRatingKey | Should -Be 789
+                $result.TargetRatingKey | Should -Be 101
+            }
+        }
+
+        It 'Should set correct PSTypeName for episode' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'episode' `
+                    -Title 'Test Episode' -ShowName 'Test Show' -Season 1 -Episode 1 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.PSObject.TypeNames[0] | Should -Be 'PlexAutomationToolkit.WatchStatusDiff'
+            }
+        }
+
+        It 'Should handle episode with high season and episode numbers' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'episode' `
+                    -Title 'Long Episode' -ShowName 'The Simpsons' -Season 35 -Episode 22 `
+                    -SourceWatched $true -TargetWatched $true `
+                    -SourceViewCount 5 -TargetViewCount 3 `
+                    -SourceRatingKey 999 -TargetRatingKey 888
+
+                $result.Season | Should -Be 35
+                $result.Episode | Should -Be 22
+            }
+        }
+
+        It 'Should handle special episode (season 0)' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'episode' `
+                    -Title 'Behind the Scenes' -ShowName 'Some Show' -Season 0 -Episode 1 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.Season | Should -Be 0
+            }
+        }
+    }
+
+    Context 'Watch Status Combinations' {
+        It 'Should handle watched on source only' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Source Only' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.SourceWatched | Should -Be $true
+                $result.TargetWatched | Should -Be $false
+            }
+        }
+
+        It 'Should handle watched on target only' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Target Only' -Year 2020 `
+                    -SourceWatched $false -TargetWatched $true `
+                    -SourceViewCount 0 -TargetViewCount 1 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.SourceWatched | Should -Be $false
+                $result.TargetWatched | Should -Be $true
+            }
+        }
+
+        It 'Should handle different view counts when both watched' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Different Counts' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $true `
+                    -SourceViewCount 5 -TargetViewCount 2 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.SourceViewCount | Should -Be 5
+                $result.TargetViewCount | Should -Be 2
+            }
+        }
+
+        It 'Should handle zero view counts' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Zero Counts' -Year 2020 `
+                    -SourceWatched $false -TargetWatched $false `
+                    -SourceViewCount 0 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.SourceViewCount | Should -Be 0
+                $result.TargetViewCount | Should -Be 0
+            }
+        }
+    }
+
+    Context 'Rating Key Handling' {
+        It 'Should preserve different rating keys' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 12345 -TargetRatingKey 67890
+
+                $result.SourceRatingKey | Should -Be 12345
+                $result.TargetRatingKey | Should -Be 67890
+            }
+        }
+
+        It 'Should handle large rating keys' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Large Keys' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 2147483647 -TargetRatingKey 2147483646
+
+                $result.SourceRatingKey | Should -Be 2147483647
+                $result.TargetRatingKey | Should -Be 2147483646
+            }
+        }
+    }
+
+    Context 'Output Type and Structure' {
+        It 'Should return PSCustomObject' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result | Should -BeOfType [PSCustomObject]
+            }
+        }
+
+        It 'Should have all expected properties' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.PSObject.Properties.Name | Should -Contain 'Title'
+                $result.PSObject.Properties.Name | Should -Contain 'Type'
+                $result.PSObject.Properties.Name | Should -Contain 'Year'
+                $result.PSObject.Properties.Name | Should -Contain 'ShowName'
+                $result.PSObject.Properties.Name | Should -Contain 'Season'
+                $result.PSObject.Properties.Name | Should -Contain 'Episode'
+                $result.PSObject.Properties.Name | Should -Contain 'SourceWatched'
+                $result.PSObject.Properties.Name | Should -Contain 'TargetWatched'
+                $result.PSObject.Properties.Name | Should -Contain 'SourceViewCount'
+                $result.PSObject.Properties.Name | Should -Contain 'TargetViewCount'
+                $result.PSObject.Properties.Name | Should -Contain 'SourceRatingKey'
+                $result.PSObject.Properties.Name | Should -Contain 'TargetRatingKey'
+            }
+        }
+
+        It 'Should have exactly 12 properties' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Test' -Year 2020 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.PSObject.Properties.Name | Should -HaveCount 12
+            }
+        }
+    }
+
+    Context 'Special Characters in Titles' {
+        It 'Should handle title with special characters' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title "Ocean's Eleven: The Heist!" -Year 2001 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.Title | Should -Be "Ocean's Eleven: The Heist!"
+            }
+        }
+
+        It 'Should handle show name with special characters' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'episode' `
+                    -Title 'Test Ep' -ShowName "Grey's Anatomy: New Beginnings" -Season 1 -Episode 1 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.ShowName | Should -Be "Grey's Anatomy: New Beginnings"
+            }
+        }
+
+        It 'Should handle unicode characters' {
+            InModuleScope PlexAutomationToolkit {
+                $result = ConvertTo-PatWatchStatusDiff -Type 'movie' `
+                    -Title 'Amélie' -Year 2001 `
+                    -SourceWatched $true -TargetWatched $false `
+                    -SourceViewCount 1 -TargetViewCount 0 `
+                    -SourceRatingKey 1 -TargetRatingKey 2
+
+                $result.Title | Should -Be 'Amélie'
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Get-PatShowEpisodes.tests.ps1
+++ b/tests/Unit/Private/Get-PatShowEpisodes.tests.ps1
@@ -1,0 +1,223 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Get-PatShowEpisodes' {
+    Context 'Parameter Validation' {
+        It 'Should throw when Server is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    Get-PatShowEpisodes -ShowRatingKey 123
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw when ShowRatingKey is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                    Get-PatShowEpisodes -Server $server
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw for ShowRatingKey of 0' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                    Get-PatShowEpisodes -Server $server -ShowRatingKey 0
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw for negative ShowRatingKey' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                    Get-PatShowEpisodes -Server $server -ShowRatingKey -1
+                }
+            } | Should -Throw
+        }
+    }
+
+    Context 'API Endpoint Construction' {
+        BeforeEach {
+            InModuleScope PlexAutomationToolkit {
+                $script:capturedUri = $null
+                Mock Join-PatUri {
+                    $script:capturedUri = "$BaseUri$Endpoint"
+                    return "$BaseUri$Endpoint"
+                }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test-token' } }
+                Mock Invoke-PatApi { return @{ Metadata = @() } }
+            }
+        }
+
+        It 'Should construct correct allLeaves endpoint' {
+            InModuleScope PlexAutomationToolkit {
+                $server = [PSCustomObject]@{ uri = 'http://plex.local:32400' }
+                Get-PatShowEpisodes -Server $server -ShowRatingKey 12345
+                $script:capturedUri | Should -Be 'http://plex.local:32400/library/metadata/12345/allLeaves'
+            }
+        }
+
+        It 'Should use server URI from Server object' {
+            InModuleScope PlexAutomationToolkit {
+                $server = [PSCustomObject]@{ uri = 'https://remote.plex.com:32400' }
+                Get-PatShowEpisodes -Server $server -ShowRatingKey 99999
+                $script:capturedUri | Should -Match '^https://remote\.plex\.com:32400'
+            }
+        }
+
+        It 'Should include ShowRatingKey in endpoint' {
+            InModuleScope PlexAutomationToolkit {
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                Get-PatShowEpisodes -Server $server -ShowRatingKey 54321
+                $script:capturedUri | Should -Match '/54321/allLeaves$'
+            }
+        }
+    }
+
+    Context 'Authentication Header' {
+        BeforeEach {
+            InModuleScope PlexAutomationToolkit {
+                $script:capturedServer = $null
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader {
+                    $script:capturedServer = $Server
+                    return @{ 'X-Plex-Token' = 'mock-token' }
+                }
+                Mock Invoke-PatApi { return @{ Metadata = @() } }
+            }
+        }
+
+        It 'Should pass Server object to Get-PatAuthenticationHeader' {
+            InModuleScope PlexAutomationToolkit {
+                $server = [PSCustomObject]@{ uri = 'http://test:32400'; token = 'secret' }
+                Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+                $script:capturedServer | Should -Not -BeNullOrEmpty
+                $script:capturedServer.uri | Should -Be 'http://test:32400'
+            }
+        }
+    }
+
+    Context 'Successful Episode Retrieval' {
+        It 'Should return episode metadata with all properties' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                $mockEpisodes = @(
+                    @{ ratingKey = '1001'; title = 'Pilot'; parentIndex = 1; index = 1; viewCount = 2 },
+                    @{ ratingKey = '1002'; title = 'Episode 2'; parentIndex = 1; index = 2; viewCount = 0 }
+                )
+                Mock Invoke-PatApi { return @{ Metadata = $mockEpisodes } }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 2
+                $result[0].ratingKey | Should -Be '1001'
+                $result[0].title | Should -Be 'Pilot'
+                $result[0].parentIndex | Should -Be 1
+                $result[0].index | Should -Be 1
+                $result[0].viewCount | Should -Be 2
+                $result[1].title | Should -Be 'Episode 2'
+            }
+        }
+
+        It 'Should return empty array when no episodes found' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                Mock Invoke-PatApi { return @{ Metadata = @() } }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should return empty array when Metadata is null' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                Mock Invoke-PatApi { return @{ Metadata = $null } }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should return empty array when result is null' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                Mock Invoke-PatApi { return $null }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 0
+            }
+        }
+    }
+
+    Context 'Error Handling' {
+        It 'Should return empty array on API error' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                Mock Invoke-PatApi { throw 'Connection failed' }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should not throw on API error' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+                Mock Invoke-PatApi { throw 'Server unavailable' }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                { Get-PatShowEpisodes -Server $server -ShowRatingKey 123 } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'Large Episode Sets' {
+        It 'Should handle shows with many episodes' {
+            InModuleScope PlexAutomationToolkit {
+                Mock Join-PatUri { return 'http://test:32400/library/metadata/123/allLeaves' }
+                Mock Get-PatAuthenticationHeader { return @{ 'X-Plex-Token' = 'test' } }
+
+                # Simulate a long-running show with 500 episodes
+                $mockEpisodes = 1..500 | ForEach-Object {
+                    @{
+                        ratingKey   = $_.ToString()
+                        title       = "Episode $_"
+                        parentIndex = [math]::Ceiling($_ / 24)
+                        index       = (($_ - 1) % 24) + 1
+                    }
+                }
+                Mock Invoke-PatApi { return @{ Metadata = $mockEpisodes } }
+
+                $server = [PSCustomObject]@{ uri = 'http://test:32400' }
+                $result = Get-PatShowEpisodes -Server $server -ShowRatingKey 123
+
+                $result | Should -HaveCount 500
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Get-WatchStatusMatchKey.tests.ps1
+++ b/tests/Unit/Private/Get-WatchStatusMatchKey.tests.ps1
@@ -1,0 +1,230 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Get-WatchStatusMatchKey' {
+    Context 'Parameter Validation' {
+        It 'Should throw when Type is not provided' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    Get-WatchStatusMatchKey -Title 'Test' -Year 2000
+                }
+            } | Should -Throw
+        }
+
+        It 'Should throw for invalid Type value' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    Get-WatchStatusMatchKey -Type 'invalid' -Title 'Test' -Year 2000
+                }
+            } | Should -Throw
+        }
+
+        It 'Should accept movie as Type' {
+            InModuleScope PlexAutomationToolkit {
+                { Get-WatchStatusMatchKey -Type 'movie' -Title 'Test' -Year 2000 } | Should -Not -Throw
+            }
+        }
+
+        It 'Should accept episode as Type' {
+            InModuleScope PlexAutomationToolkit {
+                { Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Test' -Season 1 -Episode 1 } | Should -Not -Throw
+            }
+        }
+    }
+
+    Context 'Movie Match Key Generation' {
+        It 'Should generate correct key for movie with title and year' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title 'The Matrix' -Year 1999
+                $result | Should -Be 'movie|the matrix|1999'
+            }
+        }
+
+        It 'Should normalize title to lowercase' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title 'THE MATRIX' -Year 1999
+                $result | Should -Be 'movie|the matrix|1999'
+            }
+        }
+
+        It 'Should trim whitespace from title' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title '  The Matrix  ' -Year 1999
+                $result | Should -Be 'movie|the matrix|1999'
+            }
+        }
+
+        It 'Should remove special characters from title' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title "The Matrix: Reloaded!" -Year 2003
+                $result | Should -Be 'movie|the matrix reloaded|2003'
+            }
+        }
+
+        It 'Should handle title with apostrophe' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title "Ocean's Eleven" -Year 2001
+                $result | Should -Be 'movie|oceans eleven|2001'
+            }
+        }
+
+        It 'Should handle empty title' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title '' -Year 2000
+                $result | Should -Be 'movie||2000'
+            }
+        }
+
+        It 'Should handle null title' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title $null -Year 2000
+                $result | Should -Be 'movie||2000'
+            }
+        }
+
+        It 'Should handle year as 0' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title 'Test' -Year 0
+                $result | Should -Be 'movie|test|0'
+            }
+        }
+
+        It 'Should preserve numbers in title' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title '2001: A Space Odyssey' -Year 1968
+                $result | Should -Be 'movie|2001 a space odyssey|1968'
+            }
+        }
+    }
+
+    Context 'Episode Match Key Generation' {
+        It 'Should generate correct key for episode' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 1
+                $result | Should -Be 'episode|breaking bad|S1E1'
+            }
+        }
+
+        It 'Should normalize show name to lowercase' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'BREAKING BAD' -Season 1 -Episode 1
+                $result | Should -Be 'episode|breaking bad|S1E1'
+            }
+        }
+
+        It 'Should trim whitespace from show name' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName '  Breaking Bad  ' -Season 1 -Episode 1
+                $result | Should -Be 'episode|breaking bad|S1E1'
+            }
+        }
+
+        It 'Should remove special characters from show name' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName "Grey's Anatomy" -Season 5 -Episode 10
+                $result | Should -Be 'episode|greys anatomy|S5E10'
+            }
+        }
+
+        It 'Should handle double-digit season and episode numbers' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'The Simpsons' -Season 35 -Episode 22
+                $result | Should -Be 'episode|the simpsons|S35E22'
+            }
+        }
+
+        It 'Should handle empty show name' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName '' -Season 1 -Episode 1
+                $result | Should -Be 'episode||S1E1'
+            }
+        }
+
+        It 'Should handle null show name' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName $null -Season 1 -Episode 1
+                $result | Should -Be 'episode||S1E1'
+            }
+        }
+
+        It 'Should handle season 0 (specials)' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Test Show' -Season 0 -Episode 1
+                $result | Should -Be 'episode|test show|S0E1'
+            }
+        }
+
+        It 'Should handle episode 0' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Test Show' -Season 1 -Episode 0
+                $result | Should -Be 'episode|test show|S1E0'
+            }
+        }
+
+        It 'Should preserve numbers in show name' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'episode' -ShowName '24' -Season 1 -Episode 1
+                $result | Should -Be 'episode|24|S1E1'
+            }
+        }
+    }
+
+    Context 'Output Type' {
+        It 'Should return a string' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Get-WatchStatusMatchKey -Type 'movie' -Title 'Test' -Year 2000
+                $result | Should -BeOfType [string]
+            }
+        }
+    }
+
+    Context 'Cross-Server Matching Scenarios' {
+        It 'Should generate identical keys for same movie with different casing' {
+            InModuleScope PlexAutomationToolkit {
+                $key1 = Get-WatchStatusMatchKey -Type 'movie' -Title 'the matrix' -Year 1999
+                $key2 = Get-WatchStatusMatchKey -Type 'movie' -Title 'The Matrix' -Year 1999
+                $key3 = Get-WatchStatusMatchKey -Type 'movie' -Title 'THE MATRIX' -Year 1999
+                $key1 | Should -Be $key2
+                $key2 | Should -Be $key3
+            }
+        }
+
+        It 'Should generate identical keys for same episode with different show name casing' {
+            InModuleScope PlexAutomationToolkit {
+                $key1 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'breaking bad' -Season 1 -Episode 1
+                $key2 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 1
+                $key1 | Should -Be $key2
+            }
+        }
+
+        It 'Should generate different keys for different years' {
+            InModuleScope PlexAutomationToolkit {
+                $key1 = Get-WatchStatusMatchKey -Type 'movie' -Title 'Dune' -Year 1984
+                $key2 = Get-WatchStatusMatchKey -Type 'movie' -Title 'Dune' -Year 2021
+                $key1 | Should -Not -Be $key2
+            }
+        }
+
+        It 'Should generate different keys for different episodes' {
+            InModuleScope PlexAutomationToolkit {
+                $key1 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 1
+                $key2 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 2
+                $key1 | Should -Not -Be $key2
+            }
+        }
+
+        It 'Should generate different keys for different seasons' {
+            InModuleScope PlexAutomationToolkit {
+                $key1 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 1 -Episode 1
+                $key2 = Get-WatchStatusMatchKey -Type 'episode' -ShowName 'Breaking Bad' -Season 2 -Episode 1
+                $key1 | Should -Not -Be $key2
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Compare-PatWatchStatus.tests.ps1
+++ b/tests/Unit/Public/Compare-PatWatchStatus.tests.ps1
@@ -461,12 +461,12 @@ Describe 'Compare-PatWatchStatus' {
             }
         }
 
-        It 'Returns unknown type fallback for unrecognized type' {
-            InModuleScope PlexAutomationToolkit {
-                $key = Get-WatchStatusMatchKey -Type 'music' -Title 'Some Song'
-
-                $key | Should -Be 'unknown|some song'
-            }
+        It 'Throws for unrecognized type' {
+            {
+                InModuleScope PlexAutomationToolkit {
+                    Get-WatchStatusMatchKey -Type 'music' -Title 'Some Song'
+                }
+            } | Should -Throw
         }
 
         It 'Normalizes title by removing special characters' {


### PR DESCRIPTION
## Summary

- Move `Get-WatchStatusMatchKey` to Private folder (was embedded in Compare-PatWatchStatus)
- Extract `Get-PatShowEpisodes` helper for fetching TV show episodes
- Extract `ConvertTo-PatWatchStatusDiff` helper for creating diff objects
- Reduce `Compare-PatWatchStatus` from 330 to 267 lines (~19% reduction)

## Test plan

- [x] All 1947 unit tests pass (15 skipped - PS5.1 specific)
- [x] Added 780 lines of tests for new helper functions
- [x] Updated existing test to expect throw for invalid types (ValidateSet added)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)