### PR TITLE
feat: add extended media details to Search-PatMedia output

### DIFF
--- a/PlexAutomationToolkit/Private/Format-PatDuration.ps1
+++ b/PlexAutomationToolkit/Private/Format-PatDuration.ps1
@@ -1,0 +1,59 @@
+function Format-PatDuration {
+    <#
+    .SYNOPSIS
+        Formats a duration in milliseconds as a human-readable string.
+
+    .DESCRIPTION
+        Internal helper function that converts a duration in milliseconds to a human-readable
+        string showing hours and minutes (e.g., "2h 16m") or just minutes for shorter durations.
+
+    .PARAMETER Milliseconds
+        The duration in milliseconds to format.
+
+    .OUTPUTS
+        System.String
+        Returns a formatted string representing the duration (e.g., "2h 16m", "45m", "0m").
+        Returns $null if input is $null or 0.
+
+    .EXAMPLE
+        Format-PatDuration -Milliseconds 8160000
+        Returns: "2h 16m"
+
+    .EXAMPLE
+        Format-PatDuration -Milliseconds 2700000
+        Returns: "45m"
+
+    .EXAMPLE
+        Format-PatDuration -Milliseconds 0
+        Returns: $null
+
+    .EXAMPLE
+        8160000, 2700000, 5400000 | Format-PatDuration
+        Returns: "2h 16m", "45m", "1h 30m"
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [long]
+        $Milliseconds
+    )
+
+    process {
+        if ($null -eq $Milliseconds -or $Milliseconds -eq 0) {
+            return $null
+        }
+
+        $totalMinutes = [math]::Floor($Milliseconds / 60000)
+        $hours = [math]::Floor($totalMinutes / 60)
+        $minutes = $totalMinutes % 60
+
+        if ($hours -gt 0) {
+            return "${hours}h ${minutes}m"
+        }
+        else {
+            return "${minutes}m"
+        }
+    }
+}

--- a/PlexAutomationToolkit/Public/Search-PatMedia.ps1
+++ b/PlexAutomationToolkit/Public/Search-PatMedia.ps1
@@ -73,6 +73,17 @@ function Search-PatMedia {
         - LibraryId: ID of the library section containing this item
         - LibraryName: Name of the library section
         - ServerUri: URI of the Plex server
+        - Duration: Duration in milliseconds (if applicable)
+        - DurationFormatted: Human-readable duration (e.g., "2h 16m")
+        - ContentRating: Age rating (e.g., "PG-13", "R", "TV-MA")
+        - Rating: Critic/Plex rating (0-10)
+        - AudienceRating: Audience rating (0-10)
+        - Studio: Production company/studio
+        - ViewCount: Number of times watched
+        - OriginallyAvailableAt: Original release date
+        - ShowName: TV show name (for episodes only)
+        - Season: Season number (for episodes only)
+        - Episode: Episode number (for episodes only)
     #>
     [CmdletBinding(DefaultParameterSetName = 'All')]
     [OutputType([PSCustomObject[]])]
@@ -193,16 +204,27 @@ function Search-PatMedia {
                         $itemLibraryName = if ($item.librarySectionTitle) { $item.librarySectionTitle } elseif ($resolvedSectionName) { $resolvedSectionName } else { $null }
 
                         [PSCustomObject]@{
-                            PSTypeName  = 'PlexAutomationToolkit.SearchResult'
-                            Type        = $hub.type
-                            RatingKey   = if ($item.ratingKey) { [int]$item.ratingKey } else { $null }
-                            Title       = $item.title
-                            Year        = if ($item.year) { [int]$item.year } else { $null }
-                            Summary     = $item.summary
-                            Thumb       = $item.thumb
-                            LibraryId   = $itemLibraryId
-                            LibraryName = $itemLibraryName
-                            ServerUri   = $effectiveUri
+                            PSTypeName            = 'PlexAutomationToolkit.SearchResult'
+                            Type                  = $hub.type
+                            RatingKey             = if ($item.ratingKey) { [int]$item.ratingKey } else { $null }
+                            Title                 = $item.title
+                            Year                  = if ($item.year) { [int]$item.year } else { $null }
+                            Summary               = $item.summary
+                            Thumb                 = $item.thumb
+                            LibraryId             = $itemLibraryId
+                            LibraryName           = $itemLibraryName
+                            ServerUri             = $effectiveUri
+                            Duration              = if ($item.duration) { [long]$item.duration } else { $null }
+                            DurationFormatted     = Format-PatDuration -Milliseconds $item.duration
+                            ContentRating         = $item.contentRating
+                            Rating                = if ($item.rating) { [decimal]$item.rating } else { $null }
+                            AudienceRating        = if ($item.audienceRating) { [decimal]$item.audienceRating } else { $null }
+                            Studio                = $item.studio
+                            ViewCount             = if ($item.viewCount) { [int]$item.viewCount } else { 0 }
+                            OriginallyAvailableAt = if ($item.originallyAvailableAt) { [datetime]$item.originallyAvailableAt } else { $null }
+                            ShowName              = $item.grandparentTitle
+                            Season                = if ($item.parentIndex) { [int]$item.parentIndex } else { $null }
+                            Episode               = if ($item.index) { [int]$item.index } else { $null }
                         }
                     }
                 }

--- a/tests/Unit/Private/Format-PatDuration.tests.ps1
+++ b/tests/Unit/Private/Format-PatDuration.tests.ps1
@@ -1,0 +1,148 @@
+BeforeAll {
+    # Remove any loaded instances of the module to avoid "multiple modules" error
+    Get-Module PlexAutomationToolkit -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    # Import the module from the source directory for unit testing
+    $modulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\PlexAutomationToolkit\PlexAutomationToolkit.psm1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Format-PatDuration' {
+    Context 'Hours and minutes formatting' {
+        It 'Should format duration with hours and minutes' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 8160000
+                $result | Should -Be '2h 16m'
+            }
+        }
+
+        It 'Should format 1 hour duration' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 3600000
+                $result | Should -Be '1h 0m'
+            }
+        }
+
+        It 'Should format 1 hour 30 minutes' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 5400000
+                $result | Should -Be '1h 30m'
+            }
+        }
+
+        It 'Should format long duration (3+ hours)' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 12600000
+                $result | Should -Be '3h 30m'
+            }
+        }
+    }
+
+    Context 'Minutes only formatting' {
+        It 'Should format duration less than 1 hour' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 2700000
+                $result | Should -Be '45m'
+            }
+        }
+
+        It 'Should format 30 minutes' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 1800000
+                $result | Should -Be '30m'
+            }
+        }
+
+        It 'Should format 1 minute' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 60000
+                $result | Should -Be '1m'
+            }
+        }
+
+        It 'Should format short duration (seconds only) as 0m' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 30000
+                $result | Should -Be '0m'
+            }
+        }
+    }
+
+    Context 'Null and zero handling' {
+        It 'Should return null for zero milliseconds' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 0
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should return null for null input' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds $null
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'Pipeline support' {
+        It 'Should accept value from pipeline' {
+            InModuleScope PlexAutomationToolkit {
+                $result = 7200000 | Format-PatDuration
+                $result | Should -Be '2h 0m'
+            }
+        }
+
+        It 'Should process multiple values from pipeline' {
+            InModuleScope PlexAutomationToolkit {
+                $results = @(8160000, 2700000, 5400000) | Format-PatDuration
+                $results | Should -HaveCount 3
+                $results[0] | Should -Be '2h 16m'
+                $results[1] | Should -Be '45m'
+                $results[2] | Should -Be '1h 30m'
+            }
+        }
+    }
+
+    Context 'Output type' {
+        It 'Should return a string' {
+            InModuleScope PlexAutomationToolkit {
+                $result = Format-PatDuration -Milliseconds 3600000
+                $result | Should -BeOfType [string]
+            }
+        }
+    }
+
+    Context 'Real-world media durations' {
+        It 'Should format typical movie duration (2h 16m)' {
+            InModuleScope PlexAutomationToolkit {
+                # The Matrix: 136 minutes = 8160000ms
+                $result = Format-PatDuration -Milliseconds 8160000
+                $result | Should -Be '2h 16m'
+            }
+        }
+
+        It 'Should format typical TV episode duration (45m)' {
+            InModuleScope PlexAutomationToolkit {
+                # 45 minute episode = 2700000ms
+                $result = Format-PatDuration -Milliseconds 2700000
+                $result | Should -Be '45m'
+            }
+        }
+
+        It 'Should format typical sitcom duration (22m)' {
+            InModuleScope PlexAutomationToolkit {
+                # 22 minute sitcom = 1320000ms
+                $result = Format-PatDuration -Milliseconds 1320000
+                $result | Should -Be '22m'
+            }
+        }
+
+        It 'Should format extended edition movie (3h 21m)' {
+            InModuleScope PlexAutomationToolkit {
+                # LOTR Extended: 201 minutes = 12060000ms
+                $result = Format-PatDuration -Milliseconds 12060000
+                $result | Should -Be '3h 21m'
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Search-PatMedia.tests.ps1
+++ b/tests/Unit/Public/Search-PatMedia.tests.ps1
@@ -16,53 +16,69 @@ Describe 'Search-PatMedia' {
             size = 2
             Hub  = @(
                 @{
-                    hubKey      = 'movie'
-                    type        = 'movie'
+                    hubKey        = 'movie'
+                    type          = 'movie'
                     hubIdentifier = 'movie'
-                    size        = 2
-                    title       = 'Movies'
-                    Metadata    = @(
+                    size          = 2
+                    title         = 'Movies'
+                    Metadata      = @(
                         @{
-                            ratingKey           = '12345'
-                            key                 = '/library/metadata/12345'
-                            type                = 'movie'
-                            title               = 'The Matrix'
-                            summary             = 'A computer hacker learns about the true nature of reality.'
-                            year                = 1999
-                            thumb               = '/library/metadata/12345/thumb/1234567890'
-                            librarySectionID    = 2
-                            librarySectionTitle = 'Movies'
+                            ratingKey             = '12345'
+                            key                   = '/library/metadata/12345'
+                            type                  = 'movie'
+                            title                 = 'The Matrix'
+                            summary               = 'A computer hacker learns about the true nature of reality.'
+                            year                  = 1999
+                            thumb                 = '/library/metadata/12345/thumb/1234567890'
+                            librarySectionID      = 2
+                            librarySectionTitle   = 'Movies'
+                            duration              = 8160000
+                            contentRating         = 'R'
+                            rating                = 7.7
+                            audienceRating        = 8.5
+                            studio                = 'Warner Bros.'
+                            viewCount             = 3
+                            originallyAvailableAt = '1999-03-31'
                         }
                         @{
-                            ratingKey           = '12346'
-                            key                 = '/library/metadata/12346'
-                            type                = 'movie'
-                            title               = 'The Matrix Reloaded'
-                            summary             = 'Neo and the rebels continue their fight.'
-                            year                = 2003
-                            thumb               = '/library/metadata/12346/thumb/1234567891'
-                            librarySectionID    = 2
-                            librarySectionTitle = 'Movies'
+                            ratingKey             = '12346'
+                            key                   = '/library/metadata/12346'
+                            type                  = 'movie'
+                            title                 = 'The Matrix Reloaded'
+                            summary               = 'Neo and the rebels continue their fight.'
+                            year                  = 2003
+                            thumb                 = '/library/metadata/12346/thumb/1234567891'
+                            librarySectionID      = 2
+                            librarySectionTitle   = 'Movies'
+                            duration              = 8280000
+                            contentRating         = 'R'
+                            rating                = 7.2
+                            audienceRating        = 7.8
+                            studio                = 'Warner Bros.'
+                            viewCount             = 2
+                            originallyAvailableAt = '2003-05-15'
                         }
                     )
                 }
                 @{
-                    hubKey      = 'show'
-                    type        = 'show'
+                    hubKey        = 'show'
+                    type          = 'show'
                     hubIdentifier = 'show'
-                    size        = 1
-                    title       = 'TV Shows'
-                    Metadata    = @(
+                    size          = 1
+                    title         = 'TV Shows'
+                    Metadata      = @(
                         @{
-                            ratingKey           = '22345'
-                            key                 = '/library/metadata/22345'
-                            type                = 'show'
-                            title               = 'Matrix Documentary'
-                            summary             = 'Behind the scenes of The Matrix.'
-                            year                = 2020
-                            thumb               = '/library/metadata/22345/thumb/1234567892'
-                            librarySectionID    = 3
-                            librarySectionTitle = 'TV Shows'
+                            ratingKey             = '22345'
+                            key                   = '/library/metadata/22345'
+                            type                  = 'show'
+                            title                 = 'Matrix Documentary'
+                            summary               = 'Behind the scenes of The Matrix.'
+                            year                  = 2020
+                            thumb                 = '/library/metadata/22345/thumb/1234567892'
+                            librarySectionID      = 3
+                            librarySectionTitle   = 'TV Shows'
+                            contentRating         = 'TV-14'
+                            rating                = 8.0
                         }
                     )
                 }
@@ -146,6 +162,18 @@ Describe 'Search-PatMedia' {
             $result[0].Year | Should -Be 1999
             $result[0].RatingKey | Should -Be 12345
             $result[0].LibraryName | Should -Be 'Movies'
+        }
+
+        It 'Returns new media detail properties' {
+            $result = Search-PatMedia -Query 'matrix'
+            $result[0].Duration | Should -Be 8160000
+            $result[0].DurationFormatted | Should -Be '2h 16m'
+            $result[0].ContentRating | Should -Be 'R'
+            $result[0].Rating | Should -Be 7.7
+            $result[0].AudienceRating | Should -Be 8.5
+            $result[0].Studio | Should -Be 'Warner Bros.'
+            $result[0].ViewCount | Should -Be 3
+            $result[0].OriginallyAvailableAt | Should -Be ([datetime]'1999-03-31')
         }
 
         It 'Includes results from all hub types' {
@@ -677,6 +705,132 @@ Describe 'Search-PatMedia' {
             Should -Invoke -ModuleName PlexAutomationToolkit Resolve-PatServerContext -ParameterFilter {
                 $Token -eq 'my-token'
             }
+        }
+    }
+
+    Context 'When searching returns episode results' {
+        BeforeAll {
+            $script:mockEpisodeSearchResponse = @{
+                size = 1
+                Hub  = @(
+                    @{
+                        hubKey        = 'episode'
+                        type          = 'episode'
+                        hubIdentifier = 'episode'
+                        size          = 2
+                        title         = 'Episodes'
+                        Metadata      = @(
+                            @{
+                                ratingKey             = '33001'
+                                key                   = '/library/metadata/33001'
+                                type                  = 'episode'
+                                title                 = 'Pilot'
+                                summary               = 'Walter White begins his journey.'
+                                year                  = 2008
+                                thumb                 = '/library/metadata/33001/thumb/1234567893'
+                                librarySectionID      = 3
+                                librarySectionTitle   = 'TV Shows'
+                                duration              = 3480000
+                                contentRating         = 'TV-MA'
+                                rating                = 9.0
+                                grandparentTitle      = 'Breaking Bad'
+                                parentIndex           = 1
+                                index                 = 1
+                                originallyAvailableAt = '2008-01-20'
+                            }
+                            @{
+                                ratingKey             = '33002'
+                                key                   = '/library/metadata/33002'
+                                type                  = 'episode'
+                                title                 = "Cat's in the Bag..."
+                                summary               = 'Walt and Jesse deal with consequences.'
+                                year                  = 2008
+                                thumb                 = '/library/metadata/33002/thumb/1234567894'
+                                librarySectionID      = 3
+                                librarySectionTitle   = 'TV Shows'
+                                duration              = 2880000
+                                contentRating         = 'TV-MA'
+                                grandparentTitle      = 'Breaking Bad'
+                                parentIndex           = 1
+                                index                 = 2
+                                originallyAvailableAt = '2008-01-27'
+                            }
+                        )
+                    }
+                )
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return [PSCustomObject]$script:mockServerContext
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $script:mockEpisodeSearchResponse
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                param($BaseUri, $Endpoint, $QueryString)
+                return "$BaseUri$Endpoint`?$QueryString"
+            }
+        }
+
+        It 'Returns episode-specific ShowName property' {
+            $result = Search-PatMedia -Query 'breaking'
+            $result[0].ShowName | Should -Be 'Breaking Bad'
+        }
+
+        It 'Returns episode-specific Season property' {
+            $result = Search-PatMedia -Query 'breaking'
+            $result[0].Season | Should -Be 1
+        }
+
+        It 'Returns episode-specific Episode property' {
+            $result = Search-PatMedia -Query 'breaking'
+            $result[0].Episode | Should -Be 1
+            $result[1].Episode | Should -Be 2
+        }
+
+        It 'Returns formatted duration for episodes' {
+            $result = Search-PatMedia -Query 'breaking'
+            $result[0].Duration | Should -Be 3480000
+            $result[0].DurationFormatted | Should -Be '58m'
+        }
+
+        It 'Returns content rating for episodes' {
+            $result = Search-PatMedia -Query 'breaking'
+            $result[0].ContentRating | Should -Be 'TV-MA'
+        }
+    }
+
+    Context 'When movie results have null episode fields' {
+        BeforeAll {
+            Mock -ModuleName PlexAutomationToolkit Resolve-PatServerContext {
+                return [PSCustomObject]$script:mockServerContext
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Invoke-PatApi {
+                return $script:mockSearchResponse
+            }
+
+            Mock -ModuleName PlexAutomationToolkit Join-PatUri {
+                param($BaseUri, $Endpoint, $QueryString)
+                return "$BaseUri$Endpoint`?$QueryString"
+            }
+        }
+
+        It 'Returns null ShowName for movies' {
+            $result = Search-PatMedia -Query 'matrix' -Type 'movie'
+            $result[0].ShowName | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null Season for movies' {
+            $result = Search-PatMedia -Query 'matrix' -Type 'movie'
+            $result[0].Season | Should -BeNullOrEmpty
+        }
+
+        It 'Returns null Episode for movies' {
+            $result = Search-PatMedia -Query 'matrix' -Type 'movie'
+            $result[0].Episode | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add 11 new properties to `Search-PatMedia` results with zero performance impact
- All fields are sourced from existing search API response data (no additional API calls)
- Add `Format-PatDuration` private helper for human-readable duration formatting

## New Properties

| Property | Type | Description |
|----------|------|-------------|
| Duration | long | Duration in milliseconds |
| DurationFormatted | string | Human-readable (e.g., "2h 16m", "45m") |
| ContentRating | string | Age rating (PG-13, R, TV-MA, etc.) |
| Rating | decimal | Critic/Plex rating (0-10) |
| AudienceRating | decimal | Audience rating (0-10) |
| Studio | string | Production company |
| ViewCount | int | Number of times watched |
| OriginallyAvailableAt | datetime | Release date |
| ShowName | string | TV show name (episodes only) |
| Season | int | Season number (episodes only) |
| Episode | int | Episode number (episodes only) |

## Performance
Tested against real Plex server - no measurable performance impact since all fields come from existing search API response.

## Test plan
- [x] Format-PatDuration unit tests (17 tests)
- [x] Search-PatMedia unit tests updated (44 tests)
- [x] Full unit test suite passes (1973 passed, 15 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)