### PR TITLE
feat: Add Update-PatServerToken command and CI token validation

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -158,7 +158,63 @@ jobs:
         shell: pwsh
         run: ./build.ps1 -Task Build -Bootstrap
 
+      - name: Check Integration Secrets
+        id: check-secrets
+        shell: pwsh
+        env:
+          PLEX_SERVER_URI: ${{ secrets.PLEX_SERVER_URI }}
+          PLEX_TOKEN: ${{ secrets.PLEX_TOKEN }}
+        run: |
+          if (-not $env:PLEX_SERVER_URI -or -not $env:PLEX_TOKEN) {
+            Write-Host "::warning::Integration tests skipped - PLEX_SERVER_URI or PLEX_TOKEN secrets not configured"
+            "secrets-configured=false" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          "secrets-configured=true" >> $env:GITHUB_OUTPUT
+
+      - name: Validate Plex Token
+        if: steps.check-secrets.outputs.secrets-configured == 'true'
+        shell: pwsh
+        env:
+          PLEX_SERVER_URI: ${{ secrets.PLEX_SERVER_URI }}
+          PLEX_TOKEN: ${{ secrets.PLEX_TOKEN }}
+        run: |
+          # Import the built module
+          $moduleManifest = Get-ChildItem -Path Output/PlexAutomationToolkit -Filter '*.psd1' -Recurse |
+            Select-Object -First 1
+          Import-Module $moduleManifest.FullName -Force
+
+          # Add a temporary server for validation
+          $validationServerName = 'CI-TokenValidation'
+          Add-PatServer -Name $validationServerName -ServerUri $env:PLEX_SERVER_URI -Token $env:PLEX_TOKEN -SkipValidation -Confirm:$false
+
+          try {
+            $testResult = Test-PatServer -Name $validationServerName
+
+            if (-not $testResult.IsAuthenticated) {
+              $errorLines = @(
+                "PLEX_TOKEN secret is expired or invalid (401)."
+                "To fix:"
+                "  1) Run 'Update-PatServerToken' locally to get a fresh token"
+                "  2) Update the PLEX_TOKEN secret in GitHub repo Settings > Secrets and variables > Actions"
+              )
+              Write-Host "::error::$($errorLines -join ' ')"
+              exit 1
+            }
+
+            if (-not $testResult.IsConnected) {
+              Write-Host "::warning::Plex server at $env:PLEX_SERVER_URI is not reachable. Integration tests may fail."
+            }
+            else {
+              Write-Host "Token validation successful: $($testResult.FriendlyName) v$($testResult.Version)"
+            }
+          }
+          finally {
+            Remove-PatServer -Name $validationServerName -Confirm:$false -ErrorAction 'SilentlyContinue'
+          }
+
       - name: Run Integration Tests
+        if: steps.check-secrets.outputs.secrets-configured == 'true'
         shell: pwsh
         env:
           PLEX_SERVER_URI: ${{ secrets.PLEX_SERVER_URI }}
@@ -168,11 +224,6 @@ jobs:
           PLEX_TEST_LIBRARY_PATH: ${{ secrets.PLEX_TEST_LIBRARY_PATH }}
           PLEX_ALLOW_LIBRARY_REFRESH: ${{ secrets.PLEX_ALLOW_LIBRARY_REFRESH }}
         run: |
-          if (-not $env:PLEX_SERVER_URI -or -not $env:PLEX_TOKEN) {
-            Write-Host "::warning::Integration tests skipped - PLEX_SERVER_URI or PLEX_TOKEN secrets not configured"
-            exit 0
-          }
-
           # Set up build environment (required for persistence tests)
           Set-BuildEnvironment -Force
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -182,6 +182,10 @@ jobs:
           # Import the built module
           $moduleManifest = Get-ChildItem -Path Output/PlexAutomationToolkit -Filter '*.psd1' -Recurse |
             Select-Object -First 1
+          if (-not $moduleManifest) {
+            Write-Host "::error::Module manifest not found in Output/PlexAutomationToolkit"
+            exit 1
+          }
           Import-Module $moduleManifest.FullName -Force
 
           # Add a temporary server for validation
@@ -230,6 +234,10 @@ jobs:
           # Import the built module
           $moduleManifest = Get-ChildItem -Path Output/PlexAutomationToolkit -Filter '*.psd1' -Recurse |
             Select-Object -First 1
+          if (-not $moduleManifest) {
+            Write-Host "::error::Module manifest not found in Output/PlexAutomationToolkit"
+            exit 1
+          }
           Write-Host "Importing module from: $($moduleManifest.FullName)"
           Import-Module $moduleManifest.FullName -Force
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -167,13 +167,13 @@ jobs:
         run: |
           if (-not $env:PLEX_SERVER_URI -or -not $env:PLEX_TOKEN) {
             Write-Host "::warning::Integration tests skipped - PLEX_SERVER_URI or PLEX_TOKEN secrets not configured"
-            "secrets-configured=false" >> $env:GITHUB_OUTPUT
+            "secrets_configured=false" >> $env:GITHUB_OUTPUT
             exit 0
           }
-          "secrets-configured=true" >> $env:GITHUB_OUTPUT
+          "secrets_configured=true" >> $env:GITHUB_OUTPUT
 
       - name: Validate Plex Token
-        if: steps.check-secrets.outputs.secrets-configured == 'true'
+        if: steps.check-secrets.outputs.secrets_configured == 'true'
         shell: pwsh
         env:
           PLEX_SERVER_URI: ${{ secrets.PLEX_SERVER_URI }}
@@ -214,7 +214,7 @@ jobs:
           }
 
       - name: Run Integration Tests
-        if: steps.check-secrets.outputs.secrets-configured == 'true'
+        if: steps.check-secrets.outputs.secrets_configured == 'true'
         shell: pwsh
         env:
           PLEX_SERVER_URI: ${{ secrets.PLEX_SERVER_URI }}

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -106,6 +106,7 @@ FunctionsToExport = @(
     'Test-PatLibraryPath'
     'Test-PatServer'
     'Update-PatLibrary'
+    'Update-PatServerToken'
     'Wait-PatLibraryScan'
 )
 

--- a/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
@@ -160,10 +160,15 @@ function Update-PatServerToken {
             Set-PatServerConfiguration -Configuration $configuration -ErrorAction 'Stop'
             Write-Verbose "Token stored successfully (StorageType: $($storageResult.StorageType))"
 
-            # Verify the new token works
+            # Verify the new token works (honor localUri/preferLocal if configured)
             $verified = $false
             try {
-                $verificationUri = Join-PatUri -BaseUri $server.uri -Endpoint '/'
+                $verificationBaseUri = $server.uri
+                if ($server.PSObject.Properties['preferLocal'] -and $server.preferLocal -and
+                    $server.PSObject.Properties['localUri'] -and $server.localUri) {
+                    $verificationBaseUri = $server.localUri
+                }
+                $verificationUri = Join-PatUri -BaseUri $verificationBaseUri -Endpoint '/'
                 $verificationHeaders = @{ Accept = 'application/json' }
                 $verificationHeaders['X-Plex-Token'] = $newToken
                 $null = Invoke-PatApi -Uri $verificationUri -Headers $verificationHeaders -ErrorAction 'Stop'

--- a/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
@@ -113,20 +113,24 @@ function Update-PatServerToken {
         $serverName = $server.name
         Write-Verbose "Updating token for server '$serverName'"
 
-        # Obtain token
-        $newToken = $Token
-        if (-not $newToken) {
-            Write-Verbose "No token provided, starting interactive PIN authentication"
-            $newToken = Connect-PatAccount -TimeoutSeconds $TimeoutSeconds -Force:$Force
-        }
-
         if ($PSCmdlet.ShouldProcess($serverName, 'Update authentication token')) {
+            # Obtain token (inside ShouldProcess to avoid interactive auth during -WhatIf)
+            $newToken = $Token
+            if (-not $newToken) {
+                Write-Verbose "No token provided, starting interactive PIN authentication"
+                $newToken = Connect-PatAccount -TimeoutSeconds $TimeoutSeconds -Force:$Force
+            }
+
             # Store the new token
             $storageResult = Set-PatServerToken -ServerName $serverName -Token $newToken
 
             # Update the server configuration entry
             $configuration = Get-PatServerConfiguration -ErrorAction 'Stop'
             $serverEntry = $configuration.servers | Where-Object { $_.name -eq $serverName }
+
+            if (-not $serverEntry) {
+                throw "Server entry '$serverName' was not found in configuration."
+            }
 
             if ($storageResult.StorageType -eq 'Vault') {
                 # Remove inline token if present, set vault flag

--- a/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
+++ b/PlexAutomationToolkit/Public/Update-PatServerToken.ps1
@@ -1,0 +1,184 @@
+function Update-PatServerToken {
+    <#
+    .SYNOPSIS
+        Refreshes the authentication token for a stored Plex server.
+
+    .DESCRIPTION
+        Updates the Plex authentication token for a stored server configuration.
+        This is the recommended way to fix expired or invalid tokens without
+        removing and re-adding the server.
+
+        When called without -Token, performs interactive PIN authentication via
+        Connect-PatAccount. When -Token is provided, uses the supplied token
+        directly (useful for automation or CI scenarios).
+
+        After storing the new token, verifies it by calling the Plex API root
+        endpoint and reports the result.
+
+    .PARAMETER Name
+        The name of the stored server to update. If not specified, uses the
+        default server configured via Add-PatServer -Default.
+
+    .PARAMETER Token
+        A Plex authentication token to use directly. When provided, skips the
+        interactive PIN authentication flow. Obtain a token via Connect-PatAccount
+        or from Plex account settings.
+
+    .PARAMETER TimeoutSeconds
+        Maximum time to wait for interactive PIN authorization in seconds
+        (default: 300 / 5 minutes). Only applies when -Token is not provided.
+
+    .PARAMETER Force
+        Suppresses interactive prompts during PIN authentication. When specified,
+        automatically opens the browser to the Plex authentication page.
+
+    .EXAMPLE
+        Update-PatServerToken
+
+        Refreshes the token for the default server using interactive PIN
+        authentication. Opens a browser to plex.tv/link for authorization.
+
+    .EXAMPLE
+        Update-PatServerToken -Name 'MyServer'
+
+        Refreshes the token for the server named 'MyServer' using interactive
+        PIN authentication.
+
+    .EXAMPLE
+        Update-PatServerToken -Name 'MyServer' -Token $newToken
+
+        Updates the token for 'MyServer' using a pre-obtained token, skipping
+        the interactive authentication flow.
+
+    .EXAMPLE
+        Update-PatServerToken -Force
+
+        Refreshes the default server token non-interactively, automatically
+        opening the browser for PIN authorization.
+
+    .OUTPUTS
+        PSCustomObject
+        Returns an object with the following properties:
+        - ServerName: The name of the updated server
+        - TokenUpdated: Whether the token was successfully stored
+        - Verified: Whether the new token was verified against the Plex API
+        - StorageType: Where the token is stored ('Vault' or 'Inline')
+
+    .NOTES
+        If Microsoft.PowerShell.SecretManagement is installed with a registered
+        vault, the new token is stored securely in the vault. Otherwise, the
+        token is stored in plaintext in servers.json.
+
+    .LINK
+        Connect-PatAccount
+
+    .LINK
+        Test-PatServer
+
+    .LINK
+        Add-PatServer
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $false, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Token,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 1800)]
+        [int]
+        $TimeoutSeconds = 300,
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $Force
+    )
+
+    try {
+        # Resolve target server
+        if ($Name) {
+            $server = Get-PatStoredServer -Name $Name -ErrorAction 'Stop'
+        }
+        else {
+            $server = Get-PatStoredServer -Default -ErrorAction 'Stop'
+        }
+
+        $serverName = $server.name
+        Write-Verbose "Updating token for server '$serverName'"
+
+        # Obtain token
+        $newToken = $Token
+        if (-not $newToken) {
+            Write-Verbose "No token provided, starting interactive PIN authentication"
+            $newToken = Connect-PatAccount -TimeoutSeconds $TimeoutSeconds -Force:$Force
+        }
+
+        if ($PSCmdlet.ShouldProcess($serverName, 'Update authentication token')) {
+            # Store the new token
+            $storageResult = Set-PatServerToken -ServerName $serverName -Token $newToken
+
+            # Update the server configuration entry
+            $configuration = Get-PatServerConfiguration -ErrorAction 'Stop'
+            $serverEntry = $configuration.servers | Where-Object { $_.name -eq $serverName }
+
+            if ($storageResult.StorageType -eq 'Vault') {
+                # Remove inline token if present, set vault flag
+                if ($serverEntry.PSObject.Properties['token']) {
+                    $serverEntry.PSObject.Properties.Remove('token')
+                }
+                if ($serverEntry.PSObject.Properties['tokenInVault']) {
+                    $serverEntry.tokenInVault = $true
+                }
+                else {
+                    $serverEntry | Add-Member -NotePropertyName 'tokenInVault' -NotePropertyValue $true
+                }
+            }
+            else {
+                # Store inline token, remove vault flag if present
+                if ($serverEntry.PSObject.Properties['token']) {
+                    $serverEntry.token = $storageResult.Token
+                }
+                else {
+                    $serverEntry | Add-Member -NotePropertyName 'token' -NotePropertyValue $storageResult.Token
+                }
+                if ($serverEntry.PSObject.Properties['tokenInVault']) {
+                    $serverEntry.PSObject.Properties.Remove('tokenInVault')
+                }
+            }
+
+            Set-PatServerConfiguration -Configuration $configuration -ErrorAction 'Stop'
+            Write-Verbose "Token stored successfully (StorageType: $($storageResult.StorageType))"
+
+            # Verify the new token works
+            $verified = $false
+            try {
+                $verificationUri = Join-PatUri -BaseUri $server.uri -Endpoint '/'
+                $verificationHeaders = @{ Accept = 'application/json' }
+                $verificationHeaders['X-Plex-Token'] = $newToken
+                $null = Invoke-PatApi -Uri $verificationUri -Headers $verificationHeaders -ErrorAction 'Stop'
+                $verified = $true
+                Write-Verbose "Token verification successful for server '$serverName'"
+            }
+            catch {
+                Write-Warning "Token was stored but verification failed: $($_.Exception.Message)"
+            }
+
+            [PSCustomObject]@{
+                ServerName   = $serverName
+                TokenUpdated = $true
+                Verified     = $verified
+                StorageType  = $storageResult.StorageType
+            }
+        }
+    }
+    catch {
+        throw "Failed to update server token: $($_.Exception.Message)"
+    }
+}

--- a/docs/en-US/Update-PatServerToken.md
+++ b/docs/en-US/Update-PatServerToken.md
@@ -204,9 +204,9 @@ token is stored in plaintext in servers.json.
 
 ## RELATED LINKS
 
-[Connect-PatAccount]()
+[Connect-PatAccount](Connect-PatAccount.md)
 
-[Test-PatServer]()
+[Test-PatServer](Test-PatServer.md)
 
-[Add-PatServer]()
+[Add-PatServer](Add-PatServer.md)
 

--- a/docs/en-US/Update-PatServerToken.md
+++ b/docs/en-US/Update-PatServerToken.md
@@ -1,0 +1,212 @@
+---
+external help file: PlexAutomationToolkit-help.xml
+Module Name: PlexAutomationToolkit
+online version:
+schema: 2.0.0
+---
+
+# Update-PatServerToken
+
+## SYNOPSIS
+Refreshes the authentication token for a stored Plex server.
+
+## SYNTAX
+
+```
+Update-PatServerToken [[-Name] <String>] [-Token <String>] [-TimeoutSeconds <Int32>] [-Force]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates the Plex authentication token for a stored server configuration.
+This is the recommended way to fix expired or invalid tokens without
+removing and re-adding the server.
+
+When called without -Token, performs interactive PIN authentication via
+Connect-PatAccount.
+When -Token is provided, uses the supplied token
+directly (useful for automation or CI scenarios).
+
+After storing the new token, verifies it by calling the Plex API root
+endpoint and reports the result.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Update-PatServerToken
+```
+
+Refreshes the token for the default server using interactive PIN
+authentication.
+Opens a browser to plex.tv/link for authorization.
+
+### EXAMPLE 2
+```
+Update-PatServerToken -Name 'MyServer'
+```
+
+Refreshes the token for the server named 'MyServer' using interactive
+PIN authentication.
+
+### EXAMPLE 3
+```
+Update-PatServerToken -Name 'MyServer' -Token $newToken
+```
+
+Updates the token for 'MyServer' using a pre-obtained token, skipping
+the interactive authentication flow.
+
+### EXAMPLE 4
+```
+Update-PatServerToken -Force
+```
+
+Refreshes the default server token non-interactively, automatically
+opening the browser for PIN authorization.
+
+## PARAMETERS
+
+### -Name
+The name of the stored server to update.
+If not specified, uses the
+default server configured via Add-PatServer -Default.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+A Plex authentication token to use directly.
+When provided, skips the
+interactive PIN authentication flow.
+Obtain a token via Connect-PatAccount
+or from Plex account settings.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutSeconds
+Maximum time to wait for interactive PIN authorization in seconds
+(default: 300 / 5 minutes).
+Only applies when -Token is not provided.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 300
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses interactive prompts during PIN authentication.
+When specified,
+automatically opens the browser to the Plex authentication page.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### PSCustomObject
+### Returns an object with the following properties:
+### - ServerName: The name of the updated server
+### - TokenUpdated: Whether the token was successfully stored
+### - Verified: Whether the new token was verified against the Plex API
+### - StorageType: Where the token is stored ('Vault' or 'Inline')
+## NOTES
+If Microsoft.PowerShell.SecretManagement is installed with a registered
+vault, the new token is stored securely in the vault.
+Otherwise, the
+token is stored in plaintext in servers.json.
+
+## RELATED LINKS
+
+[Connect-PatAccount]()
+
+[Test-PatServer]()
+
+[Add-PatServer]()
+

--- a/tests/Unit/Public/Update-PatServerToken.tests.ps1
+++ b/tests/Unit/Public/Update-PatServerToken.tests.ps1
@@ -218,6 +218,21 @@ Describe 'Update-PatServerToken' {
             $result.Verified | Should -Be $false
             $result.TokenUpdated | Should -Be $true
         }
+
+        It 'Should use localUri for verification when preferLocal is configured' {
+            # Set up a server with preferLocal and localUri
+            $script:mockConfiguration.servers[0] |
+                Add-Member -NotePropertyName 'preferLocal' -NotePropertyValue $true -Force
+            $script:mockConfiguration.servers[0] |
+                Add-Member -NotePropertyName 'localUri' -NotePropertyValue 'http://192.168.1.10:32400' -Force
+
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'local-token' -Confirm:$false
+
+            $result.Verified | Should -Be $true
+            Should -Invoke Join-PatUri -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $BaseUri -eq 'http://192.168.1.10:32400'
+            }
+        }
     }
 
     Context 'ShouldProcess support' {
@@ -260,6 +275,26 @@ Describe 'Update-PatServerToken' {
             }
 
             { Update-PatServerToken -Name 'DefaultServer' -Confirm:$false } | Should -Throw '*Authentication failed*'
+        }
+
+        It 'Should throw when server entry is missing from configuration' {
+            # Get-PatStoredServer succeeds but the config returned by Get-PatServerConfiguration
+            # has no matching server entry (simulates a race or corrupt config)
+            Mock -CommandName Get-PatServerConfiguration -ModuleName PlexAutomationToolkit -MockWith {
+                return [PSCustomObject]@{
+                    version = '1.0'
+                    servers = @(
+                        [PSCustomObject]@{
+                            name  = 'OtherServer'
+                            uri   = 'http://other:32400'
+                            token = 'some-token'
+                        }
+                    )
+                }
+            }
+
+            { Update-PatServerToken -Name 'DefaultServer' -Token 'token' -Confirm:$false } |
+                Should -Throw '*DefaultServer*was not found*'
         }
     }
 

--- a/tests/Unit/Public/Update-PatServerToken.tests.ps1
+++ b/tests/Unit/Public/Update-PatServerToken.tests.ps1
@@ -180,6 +180,26 @@ Describe 'Update-PatServerToken' {
             $serverEntry.PSObject.Properties['token'] | Should -BeNullOrEmpty
         }
 
+        It 'Should update existing tokenInVault property when vault storage succeeds again' {
+            # Set up a server that already uses vault storage
+            $script:mockConfiguration.servers[0] | Add-Member -NotePropertyName 'tokenInVault' -NotePropertyValue $true -Force
+            $script:mockConfiguration.servers[0].PSObject.Properties.Remove('token')
+
+            Mock -CommandName Set-PatServerToken -ModuleName PlexAutomationToolkit -MockWith {
+                param($ServerName, $Token)
+                return [PSCustomObject]@{
+                    StorageType = 'Vault'
+                    Token       = $null
+                }
+            }
+
+            Update-PatServerToken -Name 'DefaultServer' -Token 'vault-again' -Confirm:$false
+
+            $serverEntry = $script:mockConfiguration.servers | Where-Object { $_.name -eq 'DefaultServer' }
+            $serverEntry.tokenInVault | Should -Be $true
+            $serverEntry.PSObject.Properties['token'] | Should -BeNullOrEmpty
+        }
+
         It 'Should remove tokenInVault when falling back to inline storage' {
             # Set up a server that previously used vault storage
             $script:mockConfiguration.servers[0] | Add-Member -NotePropertyName 'tokenInVault' -NotePropertyValue $true -Force

--- a/tests/Unit/Public/Update-PatServerToken.tests.ps1
+++ b/tests/Unit/Public/Update-PatServerToken.tests.ps1
@@ -221,9 +221,17 @@ Describe 'Update-PatServerToken' {
     }
 
     Context 'ShouldProcess support' {
-        It 'Should support WhatIf' {
+        It 'Should support WhatIf with direct token' {
             Update-PatServerToken -Name 'DefaultServer' -Token 'whatif-token' -WhatIf
 
+            Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 0
+            Should -Invoke Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Should not invoke interactive auth when WhatIf is used without Token' {
+            Update-PatServerToken -Name 'DefaultServer' -WhatIf
+
+            Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 0
             Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 0
             Should -Invoke Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -Times 0
         }

--- a/tests/Unit/Public/Update-PatServerToken.tests.ps1
+++ b/tests/Unit/Public/Update-PatServerToken.tests.ps1
@@ -233,10 +233,12 @@ Describe 'Update-PatServerToken' {
                 throw 'Error invoking Plex API: 401 Unauthorized'
             }
 
-            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'bad-token' -Confirm:$false 3>$null
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'bad-token' -Confirm:$false -WarningVariable verificationWarning
 
             $result.Verified | Should -Be $false
             $result.TokenUpdated | Should -Be $true
+            $verificationWarning | Should -Not -BeNullOrEmpty
+            $verificationWarning[0] | Should -BeLike '*verification failed*'
         }
 
         It 'Should use localUri for verification when preferLocal is configured' {
@@ -269,6 +271,12 @@ Describe 'Update-PatServerToken' {
             Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 0
             Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 0
             Should -Invoke Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -Times 0
+        }
+
+        It 'Should return no output when WhatIf is used' {
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'whatif-token' -WhatIf
+
+            $result | Should -BeNullOrEmpty
         }
     }
 

--- a/tests/Unit/Public/Update-PatServerToken.tests.ps1
+++ b/tests/Unit/Public/Update-PatServerToken.tests.ps1
@@ -1,0 +1,283 @@
+BeforeAll {
+    # Import the module from source
+    $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $ModuleRoot = Join-Path $ProjectRoot 'PlexAutomationToolkit'
+    $moduleManifestPath = Join-Path $ModuleRoot 'PlexAutomationToolkit.psd1'
+
+    Get-Module PlexAutomationToolkit | Remove-Module -Force -ErrorAction 'Ignore'
+    Import-Module -Name $moduleManifestPath -Verbose:$false -ErrorAction 'Stop'
+}
+
+Describe 'Update-PatServerToken' {
+    BeforeEach {
+        # Mock configuration with a default server
+        $script:mockConfiguration = [PSCustomObject]@{
+            version = '1.0'
+            servers = @(
+                [PSCustomObject]@{
+                    name    = 'DefaultServer'
+                    uri     = 'http://plex:32400'
+                    default = $true
+                    token   = 'old-token-123'
+                },
+                [PSCustomObject]@{
+                    name    = 'SecondServer'
+                    uri     = 'http://plex2:32400'
+                    default = $false
+                    token   = 'old-token-456'
+                }
+            )
+        }
+
+        Mock -CommandName Get-PatStoredServer -ModuleName PlexAutomationToolkit -MockWith {
+            param($Name, $Default)
+            if ($Default) {
+                return $script:mockConfiguration.servers | Where-Object { $_.default -eq $true }
+            }
+            $server = $script:mockConfiguration.servers | Where-Object { $_.name -eq $Name }
+            if (-not $server) {
+                throw "No server found with name '$Name'"
+            }
+            return $server
+        }
+
+        Mock -CommandName Get-PatServerConfiguration -ModuleName PlexAutomationToolkit -MockWith {
+            return $script:mockConfiguration
+        }
+
+        Mock -CommandName Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -MockWith {
+            param($Configuration)
+            $script:mockConfiguration = $Configuration
+        }
+
+        Mock -CommandName Set-PatServerToken -ModuleName PlexAutomationToolkit -MockWith {
+            param($ServerName, $Token)
+            return [PSCustomObject]@{
+                StorageType = 'Inline'
+                Token       = $Token
+            }
+        }
+
+        Mock -CommandName Join-PatUri -ModuleName PlexAutomationToolkit -MockWith {
+            param($BaseUri, $Endpoint)
+            return "$BaseUri$Endpoint"
+        }
+
+        Mock -CommandName Invoke-PatApi -ModuleName PlexAutomationToolkit -MockWith {
+            return @{ friendlyName = 'Mock Server' }
+        }
+
+        Mock -CommandName Connect-PatAccount -ModuleName PlexAutomationToolkit -MockWith {
+            return 'new-interactive-token'
+        }
+    }
+
+    Context 'Named server token update' {
+        It 'Should update token for a named server' {
+            $result = Update-PatServerToken -Name 'SecondServer' -Token 'new-token-789' -Confirm:$false
+
+            $result.ServerName | Should -Be 'SecondServer'
+            $result.TokenUpdated | Should -Be $true
+            Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $ServerName -eq 'SecondServer' -and $Token -eq 'new-token-789'
+            }
+        }
+
+        It 'Should throw when server name not found' {
+            { Update-PatServerToken -Name 'NonExistent' -Token 'token' -Confirm:$false } | Should -Throw '*NonExistent*'
+        }
+    }
+
+    Context 'Default server token update' {
+        It 'Should update token for default server when no name specified' {
+            $result = Update-PatServerToken -Token 'new-default-token' -Confirm:$false
+
+            $result.ServerName | Should -Be 'DefaultServer'
+            $result.TokenUpdated | Should -Be $true
+            Should -Invoke Get-PatStoredServer -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $Default -eq $true
+            }
+        }
+
+        It 'Should throw when no default server exists and no name specified' {
+            Mock -CommandName Get-PatStoredServer -ModuleName PlexAutomationToolkit -MockWith {
+                param($Name, $Default)
+                if ($Default) {
+                    throw "No default server configured"
+                }
+            }
+
+            { Update-PatServerToken -Token 'token' -Confirm:$false } | Should -Throw '*default server*'
+        }
+    }
+
+    Context 'Interactive authentication' {
+        It 'Should call Connect-PatAccount when no Token provided' {
+            $result = Update-PatServerToken -Name 'DefaultServer' -Confirm:$false
+
+            Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 1
+            $result.TokenUpdated | Should -Be $true
+        }
+
+        It 'Should pass TimeoutSeconds to Connect-PatAccount' {
+            Update-PatServerToken -Name 'DefaultServer' -TimeoutSeconds 600 -Confirm:$false
+
+            Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $TimeoutSeconds -eq 600
+            }
+        }
+
+        It 'Should pass Force to Connect-PatAccount' {
+            Update-PatServerToken -Name 'DefaultServer' -Force -Confirm:$false
+
+            Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $Force -eq $true
+            }
+        }
+    }
+
+    Context 'Direct token supply' {
+        It 'Should use provided Token and skip interactive flow' {
+            Update-PatServerToken -Name 'DefaultServer' -Token 'direct-token' -Confirm:$false
+
+            Should -Invoke Connect-PatAccount -ModuleName PlexAutomationToolkit -Times 0
+            Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $Token -eq 'direct-token'
+            }
+        }
+    }
+
+    Context 'Token storage' {
+        It 'Should store token via Set-PatServerToken' {
+            Update-PatServerToken -Name 'DefaultServer' -Token 'store-test' -Confirm:$false
+
+            Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 1 -ParameterFilter {
+                $ServerName -eq 'DefaultServer' -and $Token -eq 'store-test'
+            }
+        }
+
+        It 'Should update inline token in configuration' {
+            Update-PatServerToken -Name 'DefaultServer' -Token 'updated-inline' -Confirm:$false
+
+            Should -Invoke Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -Times 1
+            $serverEntry = $script:mockConfiguration.servers | Where-Object { $_.name -eq 'DefaultServer' }
+            $serverEntry.token | Should -Be 'updated-inline'
+        }
+
+        It 'Should set tokenInVault when vault storage succeeds' {
+            Mock -CommandName Set-PatServerToken -ModuleName PlexAutomationToolkit -MockWith {
+                param($ServerName, $Token)
+                return [PSCustomObject]@{
+                    StorageType = 'Vault'
+                    Token       = $null
+                }
+            }
+
+            Update-PatServerToken -Name 'DefaultServer' -Token 'vault-token' -Confirm:$false
+
+            $serverEntry = $script:mockConfiguration.servers | Where-Object { $_.name -eq 'DefaultServer' }
+            $serverEntry.tokenInVault | Should -Be $true
+            $serverEntry.PSObject.Properties['token'] | Should -BeNullOrEmpty
+        }
+
+        It 'Should remove tokenInVault when falling back to inline storage' {
+            # Set up a server that previously used vault storage
+            $script:mockConfiguration.servers[0] | Add-Member -NotePropertyName 'tokenInVault' -NotePropertyValue $true -Force
+            $script:mockConfiguration.servers[0].PSObject.Properties.Remove('token')
+
+            Update-PatServerToken -Name 'DefaultServer' -Token 'inline-fallback' -Confirm:$false
+
+            $serverEntry = $script:mockConfiguration.servers | Where-Object { $_.name -eq 'DefaultServer' }
+            $serverEntry.token | Should -Be 'inline-fallback'
+            $serverEntry.PSObject.Properties['tokenInVault'] | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Token verification' {
+        It 'Should verify new token by calling API' {
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'verify-test' -Confirm:$false
+
+            Should -Invoke Invoke-PatApi -ModuleName PlexAutomationToolkit -Times 1
+            $result.Verified | Should -Be $true
+        }
+
+        It 'Should report success when verification succeeds' {
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'good-token' -Confirm:$false
+
+            $result.Verified | Should -Be $true
+            $result.TokenUpdated | Should -Be $true
+        }
+
+        It 'Should report failure when verification fails' {
+            Mock -CommandName Invoke-PatApi -ModuleName PlexAutomationToolkit -MockWith {
+                throw 'Error invoking Plex API: 401 Unauthorized'
+            }
+
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'bad-token' -Confirm:$false 3>$null
+
+            $result.Verified | Should -Be $false
+            $result.TokenUpdated | Should -Be $true
+        }
+    }
+
+    Context 'ShouldProcess support' {
+        It 'Should support WhatIf' {
+            Update-PatServerToken -Name 'DefaultServer' -Token 'whatif-token' -WhatIf
+
+            Should -Invoke Set-PatServerToken -ModuleName PlexAutomationToolkit -Times 0
+            Should -Invoke Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -Times 0
+        }
+    }
+
+    Context 'Error handling' {
+        It 'Should throw when Get-PatServerConfiguration fails' {
+            Mock -CommandName Get-PatServerConfiguration -ModuleName PlexAutomationToolkit -MockWith {
+                throw 'Configuration error'
+            }
+
+            { Update-PatServerToken -Name 'DefaultServer' -Token 'token' -Confirm:$false } | Should -Throw
+        }
+
+        It 'Should throw when Set-PatServerConfiguration fails' {
+            Mock -CommandName Set-PatServerConfiguration -ModuleName PlexAutomationToolkit -MockWith {
+                throw 'Write error'
+            }
+
+            { Update-PatServerToken -Name 'DefaultServer' -Token 'token' -Confirm:$false } | Should -Throw
+        }
+
+        It 'Should throw when Connect-PatAccount fails' {
+            Mock -CommandName Connect-PatAccount -ModuleName PlexAutomationToolkit -MockWith {
+                throw 'Authentication failed'
+            }
+
+            { Update-PatServerToken -Name 'DefaultServer' -Confirm:$false } | Should -Throw '*Authentication failed*'
+        }
+    }
+
+    Context 'Output object' {
+        It 'Should return object with correct properties' {
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'output-test' -Confirm:$false
+
+            $result.PSObject.Properties['ServerName'] | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties['TokenUpdated'] | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties['Verified'] | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties['StorageType'] | Should -Not -BeNullOrEmpty
+            $result.StorageType | Should -Be 'Inline'
+        }
+
+        It 'Should report Vault storage type when vault is used' {
+            Mock -CommandName Set-PatServerToken -ModuleName PlexAutomationToolkit -MockWith {
+                param($ServerName, $Token)
+                return [PSCustomObject]@{
+                    StorageType = 'Vault'
+                    Token       = $null
+                }
+            }
+
+            $result = Update-PatServerToken -Name 'DefaultServer' -Token 'vault-test' -Confirm:$false
+
+            $result.StorageType | Should -Be 'Vault'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Update-PatServerToken` public command that refreshes an expired Plex server token in a single step (previously required 5 manual commands)
- Split CI integration test step into three steps: Check Integration Secrets, Validate Plex Token, Run Integration Tests — expired tokens now fail fast with an actionable `::error::` message instead of producing 118 cryptic test failures
- Add 21 unit tests covering named/default server updates, interactive and direct token supply, vault and inline storage, verification, WhatIf support, and error handling

## Test Plan

- [x] All 21 new unit tests pass
- [x] All 765 help tests pass (new command's comment-based help validated)
- [x] Manifest tests pass (new function exported correctly)
- [x] Full `./build.ps1 -Task Test` suite passes
- [ ] CI (token valid): "Validate Plex Token" step passes, integration tests run
- [ ] CI (token expired): "Validate Plex Token" step fails with clear `::error::` and fix instructions
- [ ] CI (no secrets): "Check Integration Secrets" emits warning, subsequent steps skip, job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public command to refresh Plex server authentication tokens (interactive PIN or direct token), verify them, and manage secure/plain storage.
  * CI now checks integration secrets, validates Plex tokens (with cleanup and clearer messaging), and runs integration tests only when validation succeeds.

* **Documentation**
  * Added comprehensive documentation for the new token refresh command.

* **Tests**
  * Added extensive unit tests covering token refresh flows, storage, verification, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->