### PR TITLE
fix: Validate PSScriptAnalyzer availability and harden WhatIf tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache PowerShell modules
+        id: cache-lint-modules
         uses: actions/cache@v5
         with:
           path: ~/.local/share/powershell/Modules
@@ -26,6 +27,7 @@ jobs:
             ${{ runner.os }}-psmodules-lint-
 
       - name: Install PSScriptAnalyzer
+        if: steps.cache-lint-modules.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,9 +28,20 @@ jobs:
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
-          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
-            Write-Host 'PSScriptAnalyzer already available'
-          } else {
+          $moduleFound = Get-Module -ListAvailable -Name PSScriptAnalyzer
+          if ($moduleFound) {
+            try {
+              Import-Module PSScriptAnalyzer -Force -ErrorAction Stop
+              Get-Command Invoke-ScriptAnalyzer -ErrorAction Stop | Out-Null
+              Write-Host 'PSScriptAnalyzer already available'
+            }
+            catch {
+              Write-Host 'PSScriptAnalyzer cache appears invalid; reinstalling...'
+              Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+              Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+            }
+          }
+          else {
             Write-Host 'Installing PSScriptAnalyzer...'
             Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
             Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache PowerShell modules
-        id: cache-lint-modules
         uses: actions/cache@v5
         with:
           path: ~/.local/share/powershell/Modules
@@ -30,7 +29,7 @@ jobs:
         shell: pwsh
         run: |
           if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
-            Write-Host 'PSScriptAnalyzer already available (cache hit)'
+            Write-Host 'PSScriptAnalyzer already available'
           } else {
             Write-Host 'Installing PSScriptAnalyzer...'
             Set-PSRepository -Name PSGallery -InstallationPolicy Trusted

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,11 +27,15 @@ jobs:
             ${{ runner.os }}-psmodules-lint-
 
       - name: Install PSScriptAnalyzer
-        if: steps.cache-lint-modules.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          if (Get-Module -ListAvailable -Name PSScriptAnalyzer) {
+            Write-Host 'PSScriptAnalyzer already available (cache hit)'
+          } else {
+            Write-Host 'Installing PSScriptAnalyzer...'
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+          }
 
       - name: Run PSScriptAnalyzer
         shell: pwsh

--- a/tests/Integration/Public/Collection.Integration.tests.ps1
+++ b/tests/Integration/Public/Collection.Integration.tests.ps1
@@ -415,7 +415,7 @@ Describe 'Collection WhatIf Integration Tests' -Skip:(-not $script:integrationEn
                 return
             }
 
-            $whatIfTitle = "WhatIf-Test-Collection-$(Get-Random)"
+            $whatIfTitle = "WhatIf-Test-Collection-$([Guid]::NewGuid())"
             $ratingKey = [int]$script:testMediaItem.ratingKey
 
             New-PatCollection -Title $whatIfTitle -LibraryId $script:testLibrary.key -RatingKey $ratingKey -WhatIf

--- a/tests/Integration/Public/Collection.Integration.tests.ps1
+++ b/tests/Integration/Public/Collection.Integration.tests.ps1
@@ -415,13 +415,13 @@ Describe 'Collection WhatIf Integration Tests' -Skip:(-not $script:integrationEn
                 return
             }
 
-            $countBefore = (Get-PatCollection -LibraryId $script:testLibrary.key).Count
+            $whatIfTitle = "WhatIf-Test-Collection-$(Get-Random)"
             $ratingKey = [int]$script:testMediaItem.ratingKey
 
-            New-PatCollection -Title 'WhatIf-Test-Collection' -LibraryId $script:testLibrary.key -RatingKey $ratingKey -WhatIf
+            New-PatCollection -Title $whatIfTitle -LibraryId $script:testLibrary.key -RatingKey $ratingKey -WhatIf
 
-            $countAfter = (Get-PatCollection -LibraryId $script:testLibrary.key).Count
-            $countAfter | Should -Be $countBefore
+            $collections = Get-PatCollection -LibraryId $script:testLibrary.key
+            $collections.Title | Should -Not -Contain $whatIfTitle
         }
 
         It 'Remove-PatCollection WhatIf does not delete collection' {
@@ -432,12 +432,12 @@ Describe 'Collection WhatIf Integration Tests' -Skip:(-not $script:integrationEn
 
             $collections = Get-PatCollection -LibraryId $script:testLibrary.key
             if ($collections) {
-                $countBefore = $collections.Count
+                $targetCollection = $collections[0]
 
-                Remove-PatCollection -CollectionId $collections[0].CollectionId -WhatIf
+                Remove-PatCollection -CollectionId $targetCollection.CollectionId -WhatIf
 
-                $countAfter = (Get-PatCollection -LibraryId $script:testLibrary.key).Count
-                $countAfter | Should -Be $countBefore
+                $collectionsAfter = Get-PatCollection -LibraryId $script:testLibrary.key
+                $collectionsAfter.CollectionId | Should -Contain $targetCollection.CollectionId
             }
             else {
                 Set-ItResult -Skipped -Because 'No collections exist to test WhatIf'

--- a/tests/Integration/Public/Collection.Integration.tests.ps1
+++ b/tests/Integration/Public/Collection.Integration.tests.ps1
@@ -425,22 +425,23 @@ Describe 'Collection WhatIf Integration Tests' -Skip:(-not $script:integrationEn
         }
 
         It 'Remove-PatCollection WhatIf does not delete collection' {
-            if (-not $script:testLibrary) {
-                Set-ItResult -Skipped -Because 'No library available for testing'
+            if (-not $script:testLibrary -or -not $script:testMediaItem) {
+                Set-ItResult -Skipped -Because 'No library or media item available for testing'
                 return
             }
 
-            $collections = Get-PatCollection -LibraryId $script:testLibrary.key
-            if ($collections) {
-                $targetCollection = $collections[0]
+            $whatIfRemoveTitle = "WhatIf-Remove-Test-$([Guid]::NewGuid())"
+            $ratingKey = [int]$script:testMediaItem.ratingKey
+            $created = New-PatCollection -Title $whatIfRemoveTitle -LibraryId $script:testLibrary.key -RatingKey $ratingKey -PassThru
 
-                Remove-PatCollection -CollectionId $targetCollection.CollectionId -WhatIf
+            try {
+                Remove-PatCollection -CollectionId $created.CollectionId -WhatIf
 
                 $collectionsAfter = Get-PatCollection -LibraryId $script:testLibrary.key
-                $collectionsAfter.CollectionId | Should -Contain $targetCollection.CollectionId
+                $collectionsAfter.CollectionId | Should -Contain $created.CollectionId
             }
-            else {
-                Set-ItResult -Skipped -Because 'No collections exist to test WhatIf'
+            finally {
+                Remove-PatCollection -CollectionId $created.CollectionId -Confirm:$false -ErrorAction SilentlyContinue
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace GitHub Actions `if: cache-hit != 'true'` conditional with a runtime `Import-Module` + `Get-Command` validation so PSScriptAnalyzer is installed even when the cache restores a corrupt or empty archive
- Remove unused cache step ID and fix misleading log message per Copilot review
- Harden cache validation to attempt full module import and verify `Invoke-ScriptAnalyzer` is available per CodeRabbit review
- Refactor `New-PatCollection` WhatIf test to assert a GUID-named collection was **not** created, instead of comparing fragile collection counts
- Refactor `Remove-PatCollection` WhatIf test to create a dedicated collection, verify it survives the WhatIf, then clean up — eliminating shared-state flakiness

## Test Plan

- [x] PSScriptAnalyzer Lint job passes (previously failing with `Object reference not set to an instance of an object`)
- [x] Integration Tests pass on ubuntu-latest (previously failing with `Expected 3, but got 2` in WhatIf test)
- [x] All other CI jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow to detect and skip redundant module installations when already available.

* **Tests**
  * Enhanced integration test reliability for collection operations with improved validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->