### PR TITLE
feat: Replace 401 errors with actionable token recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `Update-PatServerToken` public command for refreshing an expired or invalid Plex authentication token in a single step.
+  - Interactive PIN authentication via `plex.tv/link` (default), or supply `-Token` directly for automation
+  - Stores the new token via `Microsoft.PowerShell.SecretManagement` vault when available, otherwise inline in `servers.json`
+  - Verifies the new token against the Plex API root endpoint and reports the outcome
+  - Supports `-WhatIf` and `-Confirm`
+- CI integration test workflow validates the configured `PLEX_TOKEN` secret in a dedicated pre-flight step. Expired or invalid tokens fail fast with an actionable `::error::` message instead of producing many cryptic test failures.
+
+### Changed
+
+- `401 Unauthorized` errors from the Plex API now include actionable token recovery guidance, naming `Update-PatServerToken`, `Get-PatStoredServer`, and the `-Token` parameter as concrete next steps. Detection lives centrally in the API wrapper, so every public cmdlet that hits the Plex API benefits. The original error message is appended to preserve URL/inner-exception detail for diagnostics.
+
 ## [0.10.3] - 2026-01-11
 
 ### Added

--- a/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
+++ b/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
@@ -133,12 +133,15 @@ function Invoke-PatApi {
 
                 # 401 indicates a missing, expired, or invalid token. Surface
                 # actionable guidance instead of the raw HTTP error so callers
-                # know which cmdlets to run to recover.
-                if ($errorMessage -match '\b401\b' -or $errorMessage -match 'Unauthorized') {
+                # know which cmdlets to run to recover. Match \b401\b only —
+                # bare "Unauthorized" is too broad (UnauthorizedAccessException,
+                # 403 bodies mentioning the word, etc. would misfire).
+                if ($errorMessage -match '\b401\b') {
                     throw ("Plex API returned 401 Unauthorized. The authentication token is missing, expired, or invalid. " +
                         "To resolve: refresh the token with 'Update-PatServerToken' (use -Name to target a non-default server), " +
                         "list configured servers with 'Get-PatStoredServer', " +
-                        "or pass an explicit -Token parameter to the cmdlet you are calling.")
+                        "or pass an explicit -Token parameter to the cmdlet you are calling. " +
+                        "Original error: $errorMessage")
                 }
 
                 throw "Error invoking Plex API: $errorMessage"

--- a/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
+++ b/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
@@ -129,7 +129,19 @@ function Invoke-PatApi {
 
             if (-not $isTransient -or $attempt -eq $MaxRetries) {
                 # Non-transient error or final attempt - throw immediately
-                throw "Error invoking Plex API: $($_.Exception.Message)"
+                $errorMessage = $_.Exception.Message
+
+                # 401 indicates a missing, expired, or invalid token. Surface
+                # actionable guidance instead of the raw HTTP error so callers
+                # know which cmdlets to run to recover.
+                if ($errorMessage -match '\b401\b' -or $errorMessage -match 'Unauthorized') {
+                    throw ("Plex API returned 401 Unauthorized. The authentication token is missing, expired, or invalid. " +
+                        "To resolve: refresh the token with 'Update-PatServerToken' (use -Name to target a non-default server), " +
+                        "list configured servers with 'Get-PatStoredServer', " +
+                        "or pass an explicit -Token parameter to the cmdlet you are calling.")
+                }
+
+                throw "Error invoking Plex API: $errorMessage"
             }
 
             # Calculate exponential backoff delay

--- a/tests/Unit/Private/Invoke-PatApi.tests.ps1
+++ b/tests/Unit/Private/Invoke-PatApi.tests.ps1
@@ -113,16 +113,21 @@ Describe 'Invoke-PatApi' {
             { Invoke-PatApi -Uri 'http://localhost:32400/test' } | Should -Throw "*Error invoking Plex API*"
         }
 
-        It 'Should propagate authentication errors' {
+        It 'Should surface actionable guidance for 401 Unauthorized errors' {
             Mock Invoke-RestMethod {
-                $response = [PSCustomObject]@{
-                    StatusCode = [System.Net.HttpStatusCode]::Unauthorized
-                }
-                $exception = [System.Net.WebException]::new('Unauthorized', $null, [System.Net.WebExceptionStatus]::ProtocolError, $response)
-                throw $exception
+                throw [System.Net.WebException]::new('The remote server returned an error: (401) Unauthorized.')
             }
 
-            { Invoke-PatApi -Uri 'http://localhost:32400/test' } | Should -Throw "*Error invoking Plex API*"
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' } | Should -Throw "*401 Unauthorized*Update-PatServerToken*Get-PatStoredServer*"
+        }
+
+        It 'Should include token recovery guidance when 401 is returned' {
+            Mock Invoke-RestMethod {
+                throw 'Response status code does not indicate success: 401 (Unauthorized).'
+            }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 1 -BaseDelaySeconds 0 } |
+                Should -Throw "*token is missing, expired, or invalid*"
         }
 
         It 'Should handle malformed JSON responses' {

--- a/tests/Unit/Private/Invoke-PatApi.tests.ps1
+++ b/tests/Unit/Private/Invoke-PatApi.tests.ps1
@@ -127,7 +127,24 @@ Describe 'Invoke-PatApi' {
             }
 
             { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 1 -BaseDelaySeconds 0 } |
-                Should -Throw "*token is missing, expired, or invalid*"
+                Should -Throw "*token is missing, expired, or invalid*Update-PatServerToken*Get-PatStoredServer*"
+        }
+
+        It 'Should preserve the original error message in the 401 guidance' {
+            $originalError = 'Response status code does not indicate success: 401 (Unauthorized).'
+            Mock Invoke-RestMethod { throw $originalError }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 1 -BaseDelaySeconds 0 } |
+                Should -Throw "*Original error: $originalError*"
+        }
+
+        It 'Should not trigger 401 guidance for non-401 errors that mention Unauthorized' {
+            Mock Invoke-RestMethod {
+                throw 'UnauthorizedAccessException: cannot read configuration file'
+            }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 1 -BaseDelaySeconds 0 } |
+                Should -Throw "*Error invoking Plex API*UnauthorizedAccessException*"
         }
 
         It 'Should handle malformed JSON responses' {


### PR DESCRIPTION
## Summary

- Plex API 401 responses now throw a message naming the cmdlets a user can run to recover (`Update-PatServerToken`, `Get-PatStoredServer`, explicit `-Token`) instead of just surfacing the raw HTTP status.
- Detection lives centrally in `Invoke-PatApi`, so every public cmdlet that hits the Plex API picks up the guidance automatically.
- Fixes a latent unit test that constructed `[System.Net.WebException]` with an invalid 4-arg overload — the constructor failure was masking the actual assertion, so the test was a false positive.

### Before

```
Failed to resolve section name: Failed to get Plex library information: Error invoking Plex API:
Response status code does not indicate success: 401 (Unauthorized).
```

### After

```
Failed to resolve section name: Failed to get Plex library information: Plex API returned 401
Unauthorized. The authentication token is missing, expired, or invalid. To resolve: refresh the
token with 'Update-PatServerToken' (use -Name to target a non-default server), list configured
servers with 'Get-PatStoredServer', or pass an explicit -Token parameter to the cmdlet you are
calling.
```

The outer `Failed to resolve section name:` / `Failed to get Plex library information:` wrappers from upstream catch blocks are intentionally left alone — that's a separate readability issue worth addressing on its own.

## Test plan

- [x] `pwsh -File ./build.ps1 -Task Test` — full suite green (psake exit 0)
- [x] New `Invoke-PatApi` unit tests cover both the WebException path and the raw-message path
- [x] Existing 401 retry/non-retry tests still pass (message change preserves `*401*` substring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex API error handling: 401/Unauthorized now show clear, actionable token-recovery guidance and preserve the original error text; other errors retain a consistent "Error invoking Plex API" prefix.

* **Documentation**
  * Added guidance for refreshing/supplying server tokens (instructions referencing Update-PatServerToken and Get-PatStoredServer) and CI pre-flight token validation.

* **Tests**
  * Expanded unit tests for 401/Unauthorized parsing and the new user-facing error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->