### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-27
+
 ### Added
 
 - New `Update-PatServerToken` public command for refreshing an expired or invalid Plex authentication token in a single step.

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PlexAutomationToolkit.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.10.3'
+ModuleVersion = '0.11.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')


### PR DESCRIPTION
## Summary

Cuts release v0.11.0 (MINOR bump for the new public `Update-PatServerToken` cmdlet).

- Bump `ModuleVersion` 0.10.3 → 0.11.0 in `PlexAutomationToolkit.psd1`
- Collapse `[Unreleased]` entries into `[0.11.0] - 2026-04-27` in CHANGELOG.md

## Release contents

### Added
- `Update-PatServerToken` public cmdlet (PR #31)
- CI integration token validation pre-flight step (PR #31)

### Changed
- Actionable 401 token recovery guidance in Plex API errors (PR #39)

## Post-merge

`PublishModuleToPowerShellGallery.yaml` will trigger automatically on the manifest change and:
1. Create GitHub release `v0.11.0` with auto-generated notes
2. Publish the module to PSGallery

## Test plan

- [x] CI green on the source PR (#39) prior to merge
- [x] CI green on this release PR
> Verified 2026-05-10: all 4 required checks pass on workflow run 25021015845 — PSScriptAnalyzer Lint, Unit Tests (ubuntu-latest), Unit Tests (macOS-latest), Unit Tests (windows-latest).
- [x] After merge: publish workflow creates v0.11.0 GitHub release
> Verified 2026-05-10: GitHub release v0.11.0 created 2026-04-27 by github-actions[bot] (https://github.com/tablackburn/PlexAutomationToolkit/releases/tag/v0.11.0) via publish workflow run 25021925453.
- [x] After merge: `Find-Module PlexAutomationToolkit -RequiredVersion 0.11.0` resolves on PSGallery
> Verified 2026-05-10: PSGallery returns 200 for https://www.powershellgallery.com/packages/PlexAutomationToolkit/0.11.0 — package created 2026-04-27T22:04:02 by Trent Blackburn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Update-PatServerToken` command for seamless Plex token refresh with interactive PIN authentication via plex.tv/link
  * Secure token storage using system secret vault with fallback support
  * Automatic token validation against Plex API
  * Full support for `-WhatIf` and `-Confirm` parameters

* **Improvements**
  * CI workflow now validates Plex token secrets early with clear error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
