### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-04-28
+
 ### Changed
 
 - `Add-PatServer -Force` now overwrites an existing entry with the same `-Name` instead of throwing, matching the conventional PowerShell `-Force` semantics established by `New-Item -Force`, `Copy-Item -Force`, and `Register-PSRepository -Force`. Replace is wholesale: fields not supplied on the new call (e.g. `localUri`, `preferLocal`, `default`) are not preserved, and any vault-stored token for the old entry is removed before the new entry is written. Use `Update-PatServerToken` for in-place token rotation that preserves other fields. The duplicate-name error without `-Force` now points to both recovery paths.

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PlexAutomationToolkit.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.11.0'
+ModuleVersion = '0.11.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')


### PR DESCRIPTION
Release v0.11.1.

## Summary

- Bump `ModuleVersion` to `0.11.1`.
- Promote the `[Unreleased]` `Add-PatServer -Force` overwrite entry into a dated `[0.11.1] - 2026-04-28` section.

## Highlights for this release

- `Add-PatServer -Force` now overwrites an existing entry with the same `-Name` instead of throwing (#42, closes #40). Matches PowerShell convention. Replace is wholesale; use `Update-PatServerToken` for in-place token rotation.

## Test plan

- [x] `pwsh -File ./build.ps1 -Task Test` — 2935/0 pass, manifest cross-check confirms `0.11.1` matches CHANGELOG.
- [x] CI green across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * `Add-PatServer -Force` now overwrites existing server entries with matching names instead of throwing an error
  * Overwritten entries are completely replaced; use `Update-PatServerToken` to preserve other field values during token rotation
  * Updated error messaging for duplicate name scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->