### PR TITLE
feat: Retry WSANO_DATA DNS errors and surface recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Transient DNS failures are now retried with exponential backoff in two additional cases: the Windows `WSANO_DATA` (11004) error ("The requested name is valid, but no data of the requested type was found.") which can occur when DNS records are propagating or only AAAA records are returned. After retries are exhausted, DNS failures surface a single actionable error naming `Resolve-DnsName`, `Test-NetConnection`, `Get-PatStoredServer`, and `Add-PatServer -Force` as concrete recovery steps, instead of the raw socket error wrapped through three cmdlet layers.
+- The transient-error retry classification in `Invoke-PatApi` now recognizes the Windows `WSANO_DATA` (11004) error ("The requested name is valid, but no data of the requested type was found."), which can surface while DNS records are propagating or when only AAAA records are returned. The error is now retried with the existing exponential backoff instead of failing immediately.
+- After retries are exhausted, DNS resolution failures surface a single actionable error naming `Resolve-DnsName`, `Test-NetConnection`, `Get-PatStoredServer`, and `Add-PatServer -Force` as concrete recovery steps, instead of the raw socket error wrapped through three cmdlet layers.
 
 ## [0.11.1] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Transient DNS failures are now retried with exponential backoff in two additional cases: the Windows `WSANO_DATA` (11004) error ("The requested name is valid, but no data of the requested type was found.") which can occur when DNS records are propagating or only AAAA records are returned. After retries are exhausted, DNS failures surface a single actionable error naming `Resolve-DnsName`, `Test-NetConnection`, `Get-PatStoredServer`, and `Add-PatServer -Force` as concrete recovery steps, instead of the raw socket error wrapped through three cmdlet layers.
+
 ## [0.11.1] - 2026-04-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-04-28
+
 ### Changed
 
 - The transient-error retry classification in `Invoke-PatApi` now recognizes the Windows `WSANO_DATA` (11004) error ("The requested name is valid, but no data of the requested type was found."), which can surface while DNS records are propagating or when only AAAA records are returned. The error is now retried with the existing exponential backoff instead of failing immediately.

--- a/PlexAutomationToolkit/PlexAutomationToolkit.psd1
+++ b/PlexAutomationToolkit/PlexAutomationToolkit.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PlexAutomationToolkit.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.11.1'
+ModuleVersion = '0.11.2'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')

--- a/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
+++ b/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
@@ -75,18 +75,21 @@ function Invoke-PatApi {
     Write-Debug 'Invoking Plex API with the following parameters:'
     $apiQueryParameters | Out-String | Write-Debug
 
+    # DNS failures. The "no data of the requested type" wording is the
+    # WSANO_DATA (11004) socket error that Windows raises when a hostname
+    # resolves but has no record of the queried type (commonly: only AAAA
+    # is present and the resolver asked for A). It is often transient while
+    # DNS records propagate or caches recover. Defined once so the retry
+    # classification and the post-exhaustion guidance branch cannot drift.
+    $dnsErrorPattern = 'No such host|DNS|name.+not.+resolve|no data of the requested type'
+
     # Helper function to determine if an error is transient and should be retried
     function Test-TransientError {
         param([System.Management.Automation.ErrorRecord]$ErrorRecord)
 
         $message = $ErrorRecord.Exception.Message
 
-        # DNS failures. The "no data of the requested type" wording is the
-        # WSANO_DATA (11004) socket error that Windows raises when a hostname
-        # resolves but has no record of the queried type (commonly: only AAAA
-        # is present and the resolver asked for A). It is often transient
-        # while DNS records propagate or caches recover.
-        if ($message -match 'No such host|DNS|name.+not.+resolve|no data of the requested type') {
+        if ($message -match $dnsErrorPattern) {
             return $true
         }
 
@@ -148,18 +151,19 @@ function Invoke-PatApi {
                         "Original error: $errorMessage")
                 }
 
-                # If retries were exhausted on a transient DNS/connection
-                # failure, surface a single actionable message rather than the
-                # raw socket error wrapped through three layers of cmdlets.
-                if ($isTransient -and $attempt -eq $MaxRetries) {
-                    if ($errorMessage -match 'No such host|DNS|name.+not.+resolve|no data of the requested type') {
-                        throw ("Plex API request failed after $MaxRetries attempts: DNS could not resolve the server hostname. " +
-                            "To resolve: verify the hostname with 'Resolve-DnsName <host>' (try -Type A and -Type AAAA), " +
-                            "confirm reachability with 'Test-NetConnection <host> -Port <port>', " +
-                            "check the stored URI with 'Get-PatStoredServer', " +
-                            "and re-add the server with 'Add-PatServer -Force' if the address has changed. " +
-                            "Original error: $errorMessage")
-                    }
+                # If retries were exhausted on a DNS resolution failure,
+                # surface a single actionable message rather than the raw
+                # socket error wrapped through three layers of cmdlets.
+                # Timeouts and connection-refused errors are also transient
+                # but have a different recovery story (server health, network,
+                # firewall) so they fall through to the generic message.
+                if ($isTransient -and $attempt -eq $MaxRetries -and $errorMessage -match $dnsErrorPattern) {
+                    throw ("Plex API request failed after $MaxRetries attempts: DNS could not resolve the server hostname. " +
+                        "To resolve: verify the hostname with 'Resolve-DnsName <host>' (try -Type A and -Type AAAA), " +
+                        "confirm reachability with 'Test-NetConnection <host> -Port <port>', " +
+                        "check the stored URI with 'Get-PatStoredServer', " +
+                        "and re-add the server with 'Add-PatServer -Force' if the address has changed. " +
+                        "Original error: $errorMessage")
                 }
 
                 throw "Error invoking Plex API: $errorMessage"

--- a/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
+++ b/PlexAutomationToolkit/Private/Invoke-PatApi.ps1
@@ -81,8 +81,12 @@ function Invoke-PatApi {
 
         $message = $ErrorRecord.Exception.Message
 
-        # DNS failures
-        if ($message -match 'No such host|DNS|name.+not.+resolve') {
+        # DNS failures. The "no data of the requested type" wording is the
+        # WSANO_DATA (11004) socket error that Windows raises when a hostname
+        # resolves but has no record of the queried type (commonly: only AAAA
+        # is present and the resolver asked for A). It is often transient
+        # while DNS records propagate or caches recover.
+        if ($message -match 'No such host|DNS|name.+not.+resolve|no data of the requested type') {
             return $true
         }
 
@@ -142,6 +146,20 @@ function Invoke-PatApi {
                         "list configured servers with 'Get-PatStoredServer', " +
                         "or pass an explicit -Token parameter to the cmdlet you are calling. " +
                         "Original error: $errorMessage")
+                }
+
+                # If retries were exhausted on a transient DNS/connection
+                # failure, surface a single actionable message rather than the
+                # raw socket error wrapped through three layers of cmdlets.
+                if ($isTransient -and $attempt -eq $MaxRetries) {
+                    if ($errorMessage -match 'No such host|DNS|name.+not.+resolve|no data of the requested type') {
+                        throw ("Plex API request failed after $MaxRetries attempts: DNS could not resolve the server hostname. " +
+                            "To resolve: verify the hostname with 'Resolve-DnsName <host>' (try -Type A and -Type AAAA), " +
+                            "confirm reachability with 'Test-NetConnection <host> -Port <port>', " +
+                            "check the stored URI with 'Get-PatStoredServer', " +
+                            "and re-add the server with 'Add-PatServer -Force' if the address has changed. " +
+                            "Original error: $errorMessage")
+                    }
                 }
 
                 throw "Error invoking Plex API: $errorMessage"

--- a/tests/Unit/Private/Invoke-PatApi.tests.ps1
+++ b/tests/Unit/Private/Invoke-PatApi.tests.ps1
@@ -415,6 +415,23 @@ Describe 'Invoke-PatApi' {
             $script:callCount | Should -Be 2
         }
 
+        It 'Should retry on WSANO_DATA DNS error and succeed' {
+            $script:callCount = 0
+            Mock Invoke-RestMethod {
+                $script:callCount++
+                if ($script:callCount -lt 2) {
+                    throw 'The requested name is valid, but no data of the requested type was found.'
+                }
+                return [PSCustomObject]@{
+                    MediaContainer = [PSCustomObject]@{ status = 'ok' }
+                }
+            }
+
+            $result = Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0
+            $result.status | Should -Be 'ok'
+            $script:callCount | Should -Be 2
+        }
+
         It 'Should retry on timeout and succeed' {
             $script:callCount = 0
             Mock Invoke-RestMethod {
@@ -492,6 +509,41 @@ Describe 'Invoke-PatApi' {
 
             { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0 } | Should -Throw '*No such host*'
             $script:callCount | Should -Be 3
+        }
+
+        It 'Should surface actionable DNS guidance after retries are exhausted' {
+            Mock Invoke-RestMethod {
+                throw 'No such host is known'
+            }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0 } |
+                Should -Throw "*DNS could not resolve*Resolve-DnsName*Test-NetConnection*Get-PatStoredServer*Add-PatServer -Force*"
+        }
+
+        It 'Should surface actionable DNS guidance for WSANO_DATA after retries are exhausted' {
+            Mock Invoke-RestMethod {
+                throw 'The requested name is valid, but no data of the requested type was found.'
+            }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0 } |
+                Should -Throw "*DNS could not resolve*Resolve-DnsName*Test-NetConnection*"
+        }
+
+        It 'Should preserve the original error message in the DNS guidance' {
+            $originalError = 'No such host is known'
+            Mock Invoke-RestMethod { throw $originalError }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0 } |
+                Should -Throw "*Original error: $originalError*"
+        }
+
+        It 'Should not apply DNS guidance to non-DNS transient errors' {
+            Mock Invoke-RestMethod {
+                throw '503 Service Unavailable'
+            }
+
+            { Invoke-PatApi -Uri 'http://localhost:32400/test' -MaxRetries 3 -BaseDelaySeconds 0 } |
+                Should -Throw "*Error invoking Plex API*503*"
         }
 
         It 'Should succeed after multiple retries' {


### PR DESCRIPTION
## Summary

- Broaden the transient-error regex in `Invoke-PatApi` to retry the Windows `WSANO_DATA` (11004) socket error — *"The requested name is valid, but no data of the requested type was found."* — which can occur when DNS records are propagating or when only AAAA records are returned. Previously this error fell through the existing exponential-backoff retry (1s/2s/4s) and surfaced immediately.
- After retries are exhausted on a DNS-class failure, throw a single actionable message naming `Resolve-DnsName`, `Test-NetConnection`, `Get-PatStoredServer`, and `Add-PatServer -Force` as concrete recovery steps. This mirrors the existing 401-token-recovery pattern and replaces the raw socket error wrapped through three cmdlet layers (e.g. `Update-PatLibrary` → `Get-PatLibrary` → `Invoke-PatApi`). The original error is preserved at the end for diagnostics.
- Add 4 unit tests covering: WSANO_DATA retry-and-succeed, DNS guidance after exhaustion, WSANO_DATA guidance after exhaustion, and a negative test confirming non-DNS transient errors (503) still receive the generic message.

## Motivation

A user hit `WSANO_DATA` mid-session and saw a confusing three-layer error:

```
Failed to resolve section name: Failed to get Plex library information:
Error invoking Plex API: The requested name is valid, but no data of the
requested type was found. (plex.domain.com:port)
```

The error self-resolved on the next attempt, confirming it was transient — but the existing regex `'No such host|DNS|name.+not.+resolve'` did not match the WSANO_DATA wording, so the retry path was never engaged.

## Test Plan

- [x] `pwsh -Command "Set-BuildEnvironment -Force; Invoke-Pester -Path tests/Unit/Private/Invoke-PatApi.tests.ps1"` — 57/57 pass (4 new)
- [x] CI runs full test + coverage suite
> Verified 2026-05-10: PR head c17fbfb green — CI run 25084381184 success; check-runs for c17fbfb show Unit Tests (ubuntu/macOS/windows + Windows PS5.1) all success, Integration Tests (windows + ubuntu) success, PSScriptAnalyzer Lint success, codecov/patch success.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS-related failures on Windows (including WSANO_DATA / "no data of the requested type") are now treated as transient and retried with exponential backoff.
  * After DNS retries are exhausted, users receive a single, clear recovery message listing concrete remediation commands instead of raw socket errors.

* **Tests**
  * Added unit tests covering WSANO_DATA retry behavior and DNS guidance on retry exhaustion.

* **Chores**
  * Module version updated to 0.11.2 and changelog entry added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->