### PR TITLE
fix(build): target staged output for code coverage

### DIFF
--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -29,11 +29,11 @@ properties {
     if (-not $Env:BHPSModuleManifest -or -not $Env:BHProjectName) {
         throw 'Coverage configuration requires BuildHelpers env vars. Run via ./build.ps1 or call Set-BuildEnvironment first.'
     }
-    $_moduleVersion = (Import-PowerShellDataFile -Path $Env:BHPSModuleManifest).ModuleVersion
-    $_stagedOutput = [IO.Path]::Combine($PSScriptRoot, 'Output', $Env:BHProjectName, $_moduleVersion)
+    $moduleVersion = (Import-PowerShellDataFile -Path $Env:BHPSModuleManifest).ModuleVersion
+    $stagedOutput = [IO.Path]::Combine($PSScriptRoot, 'Output', $Env:BHProjectName, $moduleVersion)
     $PSBPreference.Test.CodeCoverage.Files = @(
-        "$_stagedOutput/Public/*.ps1"
-        "$_stagedOutput/Private/*.ps1"
+        "$stagedOutput/Public/*.ps1"
+        "$stagedOutput/Private/*.ps1"
     )
     $PSBPreference.Test.CodeCoverage.Threshold = 0  # Threshold enforced by Codecov
     $PSBPreference.Test.CodeCoverage.OutputFile = [IO.Path]::Combine($PSScriptRoot, 'out', 'codeCoverage.xml')

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -21,9 +21,19 @@ properties {
     $PSBPreference.Test.OutputFile = [IO.Path]::Combine($PSScriptRoot, 'out', 'testResults.xml')
     $PSBPreference.Test.OutputFormat = 'NUnitXml'
     $PSBPreference.Test.CodeCoverage.Enabled = $true
+    # Coverage must target the staged build output, not the source tree — tests
+    # Import-Module from Output/<Name>/<Version>, so Pester only records hits
+    # against those paths. $Env:BHBuildOutput points at <root>/BuildOutput at
+    # properties-evaluation time (PowerShellBuild rewrites it later inside its
+    # tasks), so we compute the staged path from the manifest version here.
+    if (-not $Env:BHPSModuleManifest -or -not $Env:BHProjectName) {
+        throw 'Coverage configuration requires BuildHelpers env vars. Run via ./build.ps1 or call Set-BuildEnvironment first.'
+    }
+    $_moduleVersion = (Import-PowerShellDataFile -Path $Env:BHPSModuleManifest).ModuleVersion
+    $_stagedOutput = [IO.Path]::Combine($PSScriptRoot, 'Output', $Env:BHProjectName, $_moduleVersion)
     $PSBPreference.Test.CodeCoverage.Files = @(
-        "$PSScriptRoot/PlexAutomationToolkit/Public/*.ps1"
-        "$PSScriptRoot/PlexAutomationToolkit/Private/*.ps1"
+        "$_stagedOutput/Public/*.ps1"
+        "$_stagedOutput/Private/*.ps1"
     )
     $PSBPreference.Test.CodeCoverage.Threshold = 0  # Threshold enforced by Codecov
     $PSBPreference.Test.CodeCoverage.OutputFile = [IO.Path]::Combine($PSScriptRoot, 'out', 'codeCoverage.xml')

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -69,6 +69,11 @@ BeforeDiscovery {
     If the BHBuildOutput environment variable exists, it is running in a psake build, so do not
     build the module. #>
     if ($null -eq $Env:BHBuildOutput) {
+        # Populate BuildHelpers env vars so build.psake.ps1's properties block has
+        # the values it needs (BHPSModuleManifest, BHProjectName) — when running
+        # via ./build.ps1 this happens before psake; running tests in isolation
+        # bypasses that, so we do it here.
+        Set-BuildEnvironment -Path (Split-Path -Parent $PSScriptRoot) -Force
         $buildFilePath = Join-Path -Path $PSScriptRoot -ChildPath '..\build.psake.ps1'
         $invokePsakeParameters = @{
             TaskList  = 'Build'
@@ -122,6 +127,11 @@ BeforeAll {
     If the BHBuildOutput environment variable exists, it is running in a psake build, so do not
     build the module. #>
     if ($null -eq $Env:BHBuildOutput) {
+        # Populate BuildHelpers env vars so build.psake.ps1's properties block has
+        # the values it needs (BHPSModuleManifest, BHProjectName) — when running
+        # via ./build.ps1 this happens before psake; running tests in isolation
+        # bypasses that, so we do it here.
+        Set-BuildEnvironment -Path (Split-Path -Parent $PSScriptRoot) -Force
         $buildFilePath = Join-Path -Path $PSScriptRoot -ChildPath '..\build.psake.ps1'
         $invokePsakeParameters = @{
             TaskList  = 'Build'

--- a/tests/Manifest.tests.ps1
+++ b/tests/Manifest.tests.ps1
@@ -32,6 +32,11 @@ BeforeDiscovery {
     If the BHBuildOutput environment variable exists, it is running in a psake build, so do not
     build the module. #>
     if ($null -eq $Env:BHBuildOutput) {
+        # Populate BuildHelpers env vars so build.psake.ps1's properties block has
+        # the values it needs (BHPSModuleManifest, BHProjectName) — when running
+        # via ./build.ps1 this happens before psake; running tests in isolation
+        # bypasses that, so we do it here.
+        Set-BuildEnvironment -Path (Split-Path -Parent $PSScriptRoot) -Force
         $buildFilePath = Join-Path -Path $PSScriptRoot -ChildPath '..\build.psake.ps1'
         $invokePsakeParameters = @{
             TaskList  = 'Build'
@@ -65,6 +70,11 @@ BeforeAll {
     If the BHBuildOutput environment variable exists, it is running in a psake build, so do not
     build the module. #>
     if ($null -eq $Env:BHBuildOutput) {
+        # Populate BuildHelpers env vars so build.psake.ps1's properties block has
+        # the values it needs (BHPSModuleManifest, BHProjectName) — when running
+        # via ./build.ps1 this happens before psake; running tests in isolation
+        # bypasses that, so we do it here.
+        Set-BuildEnvironment -Path (Split-Path -Parent $PSScriptRoot) -Force
         $buildFilePath = Join-Path -Path $PSScriptRoot -ChildPath '..\build.psake.ps1'
         $invokePsakeParameters = @{
             TaskList  = 'Build'


### PR DESCRIPTION
## Summary

Pester reports **0% coverage** on this module because the coverage globs in `build.psake.ps1` point at the source tree (`PlexAutomationToolkit/{Public,Private}/*.ps1`) while the test files `Import-Module` from the staged build output (`Output/<Name>/<Version>/`). Pester treats the two paths as different files, so every executed line counts as "missed."

This fix points coverage at the staged output, derived from the manifest version and BuildHelpers env vars.

## Why this matters

Same root cause and same fix as upstream [tablackburn/PowerShellModuleTemplate#19](https://github.com/tablackburn/PowerShellModuleTemplate/pull/19) — the template this module was scaffolded from. Verified there at 0% → 100% coverage on identical test infrastructure.

This module's tests use `Import-Module -Name (Join-Path -Path $Env:BHBuildOutput -ChildPath "$Env:BHProjectName.psd1")` (template default), so the bug applies and the fix lands cleanly.

## Why not just use `$Env:BHBuildOutput`?

That was the first attempt — it doesn't work. PowerShellBuild only rewrites `BHBuildOutput` to the staged version path later, inside its own tasks. At psake `properties`-evaluation time, it's still BuildHelpers' default `<root>/BuildOutput`, which doesn't exist and causes Pester to bail with `Could not resolve coverage path`.

So the path has to be computed explicitly from the manifest (`$Env:BHPSModuleManifest` is populated by `Set-BuildEnvironment` before psake runs).

## Test plan

- [x] CI runs `./build.ps1 -Task Build,Test` on three OSes (plus Windows PowerShell 5.1) — all jobs green
- [x] Codecov `unittests` flag continues to report non-zero coverage; `codecov/patch` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)