### PR TITLE
ci: rename PS_GALLERY_KEY secret reference to PSGALLERY_API_KEY

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -77,5 +77,5 @@ jobs:
         if: steps.check_psgallery.outputs.exists == 'false'
         shell: pwsh
         env:
-          PSGALLERY_API_KEY: ${{ secrets.PS_GALLERY_KEY }}
+          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
         run: ./build.ps1 -Task Publish -Bootstrap


### PR DESCRIPTION
## Summary

- Updates `PublishModuleToPowerShellGallery.yaml` to read from `secrets.PSGALLERY_API_KEY` instead of `secrets.PS_GALLERY_KEY`, matching the convention established in PowerShellModuleTemplate (PR upstream-template#25).
- The env var name fed into `build.ps1` (`PSGALLERY_API_KEY`) is unchanged.
- A new `PSGALLERY_API_KEY` secret has been added with the same value as the existing `PS_GALLERY_KEY` secret, so the next publish workflow run will succeed.
- The old `PS_GALLERY_KEY` secret will be deleted after this PR merges.

## Test plan

- [x] CI passes on the standard required checks
> Verified 2026-05-10: PR head 2d40fd7 check-runs all green — PSScriptAnalyzer Lint, Unit Tests (ubuntu/macOS/windows-latest + Windows PowerShell 5.1), Integration Tests (ubuntu/windows-latest), codecov/patch, GitGuardian all success.
- [x] After merge: `PS_GALLERY_KEY` repo secret deleted
> Verified 2026-05-10: `gh secret list -R tablackburn/PlexAutomationToolkit` returns CODECOV_TOKEN, GITGUARDIAN_API_KEY, PLEX_* (5 entries), PSGALLERY_API_KEY — no PS_GALLERY_KEY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)