### PR TITLE
ci(release): include manifest path in the ReleaseNotes-write failure warning

### DIFF
--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -100,7 +100,7 @@ Task -Name 'UpdateReleaseNotes' -Depends 'Build' -Description 'Set built manifes
     catch {
         # Keep publishing unblocked: a failure here just leaves the manifest's existing
         # ReleaseNotes in place rather than aborting the release.
-        Write-Warning "Failed to set ReleaseNotes on the built manifest ($($_.Exception.Message)); leaving it unchanged."
+        Write-Warning "Failed to set ReleaseNotes on the built manifest '$builtManifest' ($($_.Exception.Message)); leaving it unchanged."
     }
 }
 


### PR DESCRIPTION
Cosmetic logging parity: the `UpdateReleaseNotes` catch warning now names the built manifest path (matching the missing-path warning above and the rest of the fleet), so logs identify which file failed to update. No behavior change.

Plex adopted the non-fatal guard in #56, just before this one-line warning-text improvement was added to the template + other modules — this brings it level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)