### PR TITLE
ci(release): fail the PSGallery check on a query error instead of assuming not-published

### DIFF
--- a/.github/workflows/PublishModuleToPowerShellGallery.yaml
+++ b/.github/workflows/PublishModuleToPowerShellGallery.yaml
@@ -52,10 +52,17 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           $version = $env:VERSION
-          $published = Find-Module -Name PlexAutomationToolkit -RequiredVersion $version -Repository PSGallery -ErrorAction SilentlyContinue
+          $findError = $null
+          $published = Find-Module -Name PlexAutomationToolkit -RequiredVersion $version -Repository PSGallery -ErrorAction SilentlyContinue -ErrorVariable findError
           if ($published) {
             Write-Host "PSGallery version $version already exists"
             "exists=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } elseif ($findError) {
+            # Find-Module records no error when the version simply isn't on the gallery,
+            # so a recorded error means the query itself failed (transient/network). Don't
+            # treat that as "not published" (publishing is gated only on this check) — fail
+            # so the run is visibly retryable instead of attempting a blind publish.
+            throw "PowerShell Gallery query failed for version ${version}: $($findError[0].Exception.Message)"
           } else {
             Write-Host "PSGallery version $version not found - will publish"
             "exists=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
Plex's `Publish` has always been gated **only** on the PSGallery check, so `Find-Module -ErrorAction SilentlyContinue` returning `$null` for **both** a genuine miss *and* a transient query failure could trigger a blind publish. Fix: capture `-ErrorVariable` — publish only on a clean miss (genuine not-found records no error, verified), `throw` on a recorded error so the run is retryable. Surfaced by CodeRabbit/Copilot during the YTMP rollout. YAML parses; no manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PowerShell Gallery publishing workflow with improved error handling. Publishing attempts now explicitly fail and become retryable when gallery query issues occur, providing better visibility into publishing status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/PlexAutomationToolkit/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->