### PR TITLE
fix: replace TCP readiness check with signal file to fix flaky Linux test

### DIFF
--- a/tests/Integration/Private/FileDownload.Integration.tests.ps1
+++ b/tests/Integration/Private/FileDownload.Integration.tests.ps1
@@ -43,29 +43,19 @@ BeforeAll {
         return $port
     }
 
-    # Helper function to wait for server to be ready with polling
+    # Helper function to wait for server to be ready by polling for a signal file
     function Wait-ServerReady {
         param(
-            [int]$Port,
+            [Parameter(Mandatory)]
+            [string]$SignalFile,
             [int]$TimeoutMs = 5000,
             [int]$PollIntervalMs = 50
         )
 
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         while ($stopwatch.ElapsedMilliseconds -lt $TimeoutMs) {
-            try {
-                $client = [System.Net.Sockets.TcpClient]::new()
-                $result = $client.BeginConnect('localhost', $Port, $null, $null)
-                $success = $result.AsyncWaitHandle.WaitOne(100)
-                if ($success) {
-                    $client.EndConnect($result)
-                    $client.Close()
-                    return $true
-                }
-                $client.Close()
-            }
-            catch {
-                # Server not ready yet
+            if (Test-Path -Path $SignalFile) {
+                return $true
             }
             Start-Sleep -Milliseconds $PollIntervalMs
         }
@@ -82,8 +72,11 @@ BeforeAll {
             [switch]$CaptureHeaders
         )
 
+        $signalId = [guid]::NewGuid().ToString('N')
+        $readySignalFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "pat-test-ready-$signalId.signal"
+
         $job = Start-Job -ScriptBlock {
-            param($port, $data, $statusCode, $captureHeaders)
+            param($port, $data, $statusCode, $captureHeaders, $readySignalFile)
 
             $result = @{
                 ReceivedHeaders = @{}
@@ -96,8 +89,13 @@ BeforeAll {
             try {
                 $listener.Start()
 
-                # Use async with timeout to prevent hanging
+                # Begin async wait before signaling readiness so the
+                # listener is in GetContextAsync() when the test fires
                 $contextTask = $listener.GetContextAsync()
+
+                # Signal that the listener is ready to accept requests
+                [System.IO.File]::WriteAllText($readySignalFile, 'ready')
+
                 if (-not $contextTask.Wait(30000)) {
                     throw "Timeout waiting for request"
                 }
@@ -132,12 +130,17 @@ BeforeAll {
             }
 
             return $result
-        } -ArgumentList $Port, $ResponseData, $StatusCode, $CaptureHeaders.IsPresent
+        } -ArgumentList $Port, $ResponseData, $StatusCode, $CaptureHeaders.IsPresent, $readySignalFile
 
-        # Wait for server to be ready with polling
-        $ready = Wait-ServerReady -Port $Port -TimeoutMs 5000
+        # Wait for server to signal it is ready to accept HTTP requests
+        $ready = Wait-ServerReady -SignalFile $readySignalFile -TimeoutMs 5000
         if (-not $ready) {
-            Write-Warning "Server may not be ready on port $Port"
+            throw "Server failed to become ready on port $Port within timeout"
+        }
+
+        # Clean up signal file
+        if (Test-Path -Path $readySignalFile) {
+            Remove-Item -Path $readySignalFile -Force
         }
 
         return $job

--- a/tests/Integration/Private/FileDownload.Integration.tests.ps1
+++ b/tests/Integration/Private/FileDownload.Integration.tests.ps1
@@ -47,6 +47,7 @@ BeforeAll {
     function Wait-ServerReady {
         param(
             [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
             [string]$SignalFile,
             [int]$TimeoutMs = 5000,
             [int]$PollIntervalMs = 50
@@ -132,15 +133,28 @@ BeforeAll {
             return $result
         } -ArgumentList $Port, $ResponseData, $StatusCode, $CaptureHeaders.IsPresent, $readySignalFile
 
-        # Wait for server to signal it is ready to accept HTTP requests
-        $ready = Wait-ServerReady -SignalFile $readySignalFile -TimeoutMs 5000
-        if (-not $ready) {
-            throw "Server failed to become ready on port $Port within timeout"
+        # Wait for server to signal it is ready to accept HTTP requests. Wrap the
+        # wait so a failed startup always stops the background job and removes the
+        # readiness signal file instead of leaking them.
+        try {
+            $ready = Wait-ServerReady -SignalFile $readySignalFile -TimeoutMs 5000
+            if (-not $ready) {
+                throw "Server failed to become ready on port $Port within timeout"
+            }
         }
-
-        # Clean up signal file
-        if (Test-Path -Path $readySignalFile) {
-            Remove-Item -Path $readySignalFile -Force
+        catch {
+            $startupError = $_
+            # Stop and remove the background job so a failed startup does not leak
+            # the HttpListener and its 30-second GetContextAsync wait.
+            $job | Stop-Job -ErrorAction 'SilentlyContinue'
+            $job | Remove-Job -Force -ErrorAction 'SilentlyContinue'
+            throw $startupError
+        }
+        finally {
+            # Always remove the readiness signal file, even when readiness times out.
+            if (Test-Path -Path $readySignalFile) {
+                Remove-Item -Path $readySignalFile -Force
+            }
         }
 
         return $job


### PR DESCRIPTION
## Reviving forgotten work
This restores a fix you authored on 2026-02-24 (`85de79c`) that was committed onto the `pre-commit-ci-update-config` bot branch and **never merged** — it's not in `main`. Cherry-picked cleanly onto current `main` (the integration-test file hasn't diverged since).

## What it does
Replaces a TCP readiness check with a **signal-file** approach in `Private/FileDownload.Integration.tests.ps1` (+24/−21) to fix a flaky Linux integration test.

## Why now
We hit a **flaky download test on Plex #55** (`Failed to download file… connection forcibly closed`) while reviewing the test-scaffolding PR — this forgotten fix targets that same FileDownload test flakiness, so it's worth landing.

## Note
Original work is 3 months old; worth a fresh look to confirm it's still the right approach against current `main` before merging. CI (incl. integration, if it runs here) will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved internal test infrastructure and reliability mechanisms for integration testing.

---

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/PlexAutomationToolkit/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->