### PR TITLE
fix(tests): run the param-help check (populate vars in BeforeDiscovery)

### DIFF
--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -253,7 +253,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
 
         # Shouldn't find extra parameters in help
         It 'finds help parameter in code: <_>' {
-            $_ -in $parameterNames | Should -Be $true
+            $_ -in $commandParameterNames | Should -Be $true
         }
     }
 }

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -144,11 +144,16 @@ BeforeAll {
 Describe "Test help for <_.Name>" -ForEach $commands {
 
     BeforeDiscovery {
-        # Get command help, parameters, and links
+        # Get command help, parameters, and links. These are duplicated in BeforeAll
+        # below; they must also exist here because the nested Context blocks use them in
+        # -ForEach, which Pester evaluates during discovery (before BeforeAll runs).
         $command               = $_
+        $commandName           = $command.Name
         $commandHelp           = Get-Help -Name $command.Name -ErrorAction 'SilentlyContinue'
         $commandParameters     = global:FilterOutCommonParameters -Parameters $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
+        $helpParameters        = global:FilterOutCommonParameters -Parameters $commandHelp.Parameters.Parameter
+        $helpParameterNames    = $helpParameters.Name
         $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri | Where-Object { $_ -match '^https?://' }
     }
 


### PR DESCRIPTION
Propagates **PowerShellModuleTemplate#35** (canonical fix, merged).

The `Help.tests.ps1` 'help parameter help' Context used `-Foreach $helpParameterNames` with the variable set only in `BeforeAll`. Since Pester evaluates `-Foreach` at **discovery**, the collection was `$null` then and the Context expanded to **zero tests** — the param-help check was a silent no-op. Fix: populate `$helpParameters`/`$helpParameterNames` (and `$commandName`, used in the Context name) in `BeforeDiscovery`.

This is the surgical discovery fix on current `main`. The broader scaffolding alignment (this repo's open `style/align-test-scaffolding-with-template` PR) is a separate, optional thread. No source/manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)