### PR TITLE
ci: pin PSScriptAnalyzer version in the lint job

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,7 +46,7 @@ jobs:
           else {
             Write-Host "Installing PSScriptAnalyzer $requiredVersion..."
             Set-PSRepository -Name 'PSGallery' -InstallationPolicy 'Trusted'
-            Install-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force -Scope 'CurrentUser'
+            Install-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force -Scope 'CurrentUser' -ErrorAction 'Stop'
           }
 
       - name: Run PSScriptAnalyzer
@@ -58,7 +58,7 @@ jobs:
           # dynamic assembly in this version of the runtime."
           $manifest = Import-PowerShellDataFile -Path './build.depend.psd1'
           $requiredVersion = $manifest['PSScriptAnalyzer'].Version
-          Import-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force
+          Import-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force -ErrorAction 'Stop'
 
           $results = Invoke-ScriptAnalyzer -Path ./PlexAutomationToolkit -Recurse -Settings PSGallery -ReportSummary
           $errors = $results | Where-Object { $_.Severity -eq 'Error' }

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache PowerShell modules
-        id: cache-lint-modules
         uses: actions/cache@v5
         with:
           path: ~/.local/share/powershell/Modules
@@ -27,31 +26,40 @@ jobs:
             ${{ runner.os }}-psmodules-lint-
 
       - name: Install PSScriptAnalyzer
-        if: steps.cache-lint-modules.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          $moduleFound = Get-Module -ListAvailable -Name PSScriptAnalyzer
-          if ($moduleFound) {
-            try {
-              Import-Module PSScriptAnalyzer -Force -ErrorAction Stop
-              Get-Command Invoke-ScriptAnalyzer -ErrorAction Stop | Out-Null
-              Write-Host 'PSScriptAnalyzer already available'
-            }
-            catch {
-              Write-Host 'PSScriptAnalyzer cache appears invalid; reinstalling...'
-              Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-              Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
-            }
+          # Pin to the same version the rest of the build uses (build.depend.psd1) so the
+          # lint job never loads a version that mismatches the runner's PowerShell runtime.
+          $manifest = Import-PowerShellDataFile -Path './build.depend.psd1'
+          $requiredVersion = $manifest['PSScriptAnalyzer'].Version
+          if (-not $requiredVersion) {
+            throw 'PSScriptAnalyzer version not found in build.depend.psd1'
+          }
+
+          # Verify the exact version is present even on a cache hit; a cache restored from an
+          # earlier (unpinned) run can hold a different version, so check before trusting it.
+          $installed = Get-Module -ListAvailable -Name 'PSScriptAnalyzer' |
+            Where-Object { $_.Version -eq $requiredVersion }
+          if ($installed) {
+            Write-Host "PSScriptAnalyzer $requiredVersion already available"
           }
           else {
-            Write-Host 'Installing PSScriptAnalyzer...'
-            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+            Write-Host "Installing PSScriptAnalyzer $requiredVersion..."
+            Set-PSRepository -Name 'PSGallery' -InstallationPolicy 'Trusted'
+            Install-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force -Scope 'CurrentUser'
           }
 
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
+          # Import the pinned version explicitly so exactly one PSScriptAnalyzer assembly loads.
+          # Without this, a bare Invoke-ScriptAnalyzer can auto-load the runner image's bundled
+          # copy alongside the cached one and crash with "more than one dynamic module in each
+          # dynamic assembly in this version of the runtime."
+          $manifest = Import-PowerShellDataFile -Path './build.depend.psd1'
+          $requiredVersion = $manifest['PSScriptAnalyzer'].Version
+          Import-Module -Name 'PSScriptAnalyzer' -RequiredVersion $requiredVersion -Force
+
           $results = Invoke-ScriptAnalyzer -Path ./PlexAutomationToolkit -Recurse -Settings PSGallery -ReportSummary
           $errors = $results | Where-Object { $_.Severity -eq 'Error' }
 


### PR DESCRIPTION
## Summary

- The `PSScriptAnalyzer Lint` job installed PSScriptAnalyzer **unpinned** and called `Invoke-ScriptAnalyzer` with no explicit `Import-Module`, so it ignored the `1.24.0` pin in `build.depend.psd1` (only the build/test jobs honor it, via PSDepend).
- On a cache hit the install step was skipped entirely, letting the runner image's bundled copy load alongside the cached one and crash with *"You cannot have more than one dynamic module in each dynamic assembly in this version of the runtime."* This failed CI on `main` after #55, while the identical PR tree had passed minutes earlier — confirming it was environmental, not a lint violation.
- Fix: read the pinned version from `build.depend.psd1`, install that exact version (verified present even on a cache hit), and `Import-Module -RequiredVersion` it explicitly before `Invoke-ScriptAnalyzer` so exactly one assembly version loads. The cache key already hashes `build.depend.psd1`, so the installed version and cache stay coupled to a single source of truth.

## Test Plan

- [x] YAML parses; both embedded `pwsh` blocks parse cleanly
- [x] End-to-end run in a `pwsh 7.5 / ubuntu-24.04` container under the failure condition: with `1.25.0` pre-polluting the module path, the step still installs and loads exactly `1.24.0` and analyzes cleanly (0 errors)
- [ ] CI `PSScriptAnalyzer Lint` job passes on this PR

## Breaking Changes

None. Behavior change is confined to the lint job's module install/import.

## Notes

A separate follow-up (discussed but intentionally **not** included here) may unify the lint ruleset with the in-build analysis and revisit the now-likely-obsolete Linux/macOS PSScriptAnalyzer workaround in `build.psake.ps1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI linting reliability by ensuring the pinned analysis module version is detected, imported, and used consistently.
  * Removed dependency on a cache-based gate for module setup, reducing flaky failures caused by multiple module instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/PlexAutomationToolkit/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->