### PR TITLE
chore: bump PSScriptAnalyzer to 1.25.0

### DIFF
--- a/build.depend.psd1
+++ b/build.depend.psd1
@@ -23,7 +23,7 @@
         Version = '0.7.3'
     }
     'PSScriptAnalyzer' = @{
-        Version = '1.24.0'
+        Version = '1.25.0'
     }
     # Parses CHANGELOG.md (Keep a Changelog format) so the Publish task can populate the
     # built manifest's PSData.ReleaseNotes from the matching version's entry.


### PR DESCRIPTION
## Summary

- Bump the pinned `PSScriptAnalyzer` build dependency in `build.depend.psd1` from `1.24.0` to `1.25.0` (latest stable on the PowerShell Gallery).

## Test Plan

- [ ] CI passes (lint + unit/integration tests) with PSScriptAnalyzer 1.25.0

## Breaking Changes

None — development/build dependency only; no runtime or public API change.

## Notes

1.25.0 is already in use on `PowerShellModuleTemplate` and `JsmOperations` with green CI, so this aligns the remaining repos with the current stable analyzer.
