### PR TITLE
fix: retry the in-build Lint task on PSScriptAnalyzer's transient null reference

### DIFF
--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -128,7 +128,32 @@ Task -Name 'Lint' -Depends 'Build' -Description 'Run PSScriptAnalyzer against th
         Settings = $PSBPreference.Test.ScriptAnalysis.SettingsPath
         Recurse  = $true
     }
-    $analysisResult = Invoke-ScriptAnalyzer @analyzeParameters
+    # PSScriptAnalyzer 1.25.0 intermittently throws a NullReferenceException
+    # ("Object reference not set to an instance of an object.") from inside the
+    # analyzer engine - a transient failure that has struck both Linux and Windows
+    # CI runners (PRs #65 and #66) on otherwise-passing builds. It is not a code
+    # defect and clears on a retry, so attempt the analysis a few times, retrying
+    # only that specific null reference and letting any genuine error surface
+    # immediately.
+    $maxAnalysisAttempts = 3
+    $analysisResult = $null
+    for ($analysisAttempt = 1; $analysisAttempt -le $maxAnalysisAttempts; $analysisAttempt++) {
+        try {
+            $analysisResult = Invoke-ScriptAnalyzer @analyzeParameters
+            break
+        }
+        catch {
+            $isTransientNullReference =
+                $_.Exception -is [NullReferenceException] -or
+                $_.Exception.InnerException -is [NullReferenceException] -or
+                $_.Exception.Message -like '*Object reference not set to an instance of an object*'
+            if (-not $isTransientNullReference -or $analysisAttempt -eq $maxAnalysisAttempts) {
+                throw
+            }
+            Write-Warning "PSScriptAnalyzer threw a transient null reference on attempt $analysisAttempt of $maxAnalysisAttempts; retrying. ($($_.Exception.Message))"
+            Start-Sleep -Seconds 1
+        }
+    }
     if ($analysisResult) {
         $analysisResult | Format-Table -AutoSize | Out-String | Write-Host
     }


### PR DESCRIPTION
## Summary

- PSScriptAnalyzer 1.25.0 intermittently throws `Object reference not set to an instance of an object.` from inside the analyzer engine, failing the in-build `Lint` task (`build.psake.ps1`) on otherwise-green builds.
- This flake hit **both** Linux (#65) and Windows (#66) CI runners at random — it is **not** platform-specific, so the previously-removed non-Windows disable would not have covered it.
- The `Lint` task now retries `Invoke-ScriptAnalyzer` up to **three times** on that specific null reference (matched by exception type, inner exception, or message), while letting any **genuine** analysis error surface immediately and still failing after the final attempt.

## Test Plan

- [x] `build.psake.ps1` parses clean; no new PSScriptAnalyzer findings introduced
- [x] `pwsh -File ./build.ps1 -Task Lint` passes locally (errors: 0)
- [x] Retry semantics simulated:
  - [x] null reference on attempts 1–2, success on 3 → task succeeds
  - [x] a genuine (non-null-ref) error → rethrown immediately, no retry
  - [x] null reference on every attempt → rethrown after 3 attempts (build fails)
- [ ] CI green across all OS matrices

## Breaking Changes

None — build/CI tooling only; no module behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by implementing automatic recovery for intermittent linting failures. The linting process now handles transient issues gracefully, reducing build failures and enabling smoother development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tablackburn/PlexAutomationToolkit/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->